### PR TITLE
chore: update workflow references

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   integration_tests:
-    uses: epam/ai-dial-ci/.github/workflows/trigger_integration_tests.yml@1.0.0
+    uses: epam/ai-dial-ci/.github/workflows/trigger_integration_tests.yml@1.0.2
     secrets: inherit

--- a/.github/workflows/pr_check_tests.yml
+++ b/.github/workflows/pr_check_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/test_python_package.yml@1.0.0
+    uses: epam/ai-dial-ci/.github/workflows/test_python_package.yml@1.0.2
     secrets: inherit
     with:
       bypass_checks: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@1.0.0
+    uses: epam/ai-dial-ci/.github/workflows/publish_python_package.yml@1.0.2
     secrets: inherit
     with:
       bypass_checks: false


### PR DESCRIPTION
This PR:
- fixes release notes generation for newly-created `release-*` branches