### PR TITLE
feat: supported otlp export for metrics and logs

### DIFF
--- a/aidial_sdk/telemetry/init.py
+++ b/aidial_sdk/telemetry/init.py
@@ -1,4 +1,11 @@
+import logging
+
 from fastapi import FastAPI
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    OTLPMetricExporter,
+)
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
 )
@@ -15,7 +22,12 @@ from opentelemetry.instrumentation.system_metrics import (
 )
 from opentelemetry.instrumentation.urllib import URLLibInstrumentor
 from opentelemetry.metrics import set_meter_provider
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.export import (
+    PeriodicExportingMetricReader,
+)
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -31,10 +43,12 @@ def init_telemetry(
     config: TelemetryConfig,
 ):
     resource = Resource.create(
-        attributes={SERVICE_NAME: config.service_name}
-        if config.service_name
-        else None
+        attributes=(
+            {SERVICE_NAME: config.service_name} if config.service_name else None
+        )
     )
+
+    log_level = logger.getEffectiveLevel()
 
     if config.tracing is not None:
         tracer_provider = TracerProvider(resource=resource)
@@ -52,21 +66,46 @@ def init_telemetry(
         HTTPXClientInstrumentor().instrument()
 
         if config.tracing.logging:
+            # Setting the root logger format in order to include
+            # tracing information: span_id, trace_id
             LoggingInstrumentor().instrument(
                 set_logging_format=True,
-                log_level=logger.getEffectiveLevel(),
+                log_level=log_level,
             )
 
-    if config.metrics is not None:
-        set_meter_provider(
-            MeterProvider(
-                resource=resource, metric_readers=[PrometheusMetricReader()]
+    if config.logs is not None:
+        # Adding a handler to the root logger which exports the logs to OTLP
+        provider = LoggerProvider(resource=resource)
+
+        if config.logs.otlp_export:
+            provider.add_log_record_processor(
+                BatchLogRecordProcessor(OTLPLogExporter())
             )
+
+        set_logger_provider(provider)
+
+        handler = LoggingHandler(level=log_level)
+        logging.getLogger().addHandler(handler)
+
+    if config.metrics is not None:
+        metric_readers = []
+
+        if config.metrics.prometheus_export:
+            metric_readers.append(PrometheusMetricReader())
+
+        if config.metrics.otlp_export:
+            metric_readers.append(
+                PeriodicExportingMetricReader(OTLPMetricExporter())
+            )
+
+        set_meter_provider(
+            MeterProvider(resource=resource, metric_readers=metric_readers)
         )
 
         SystemMetricsInstrumentor().instrument()
 
-        start_http_server(port=config.metrics.port)
+        if config.metrics.prometheus_export:
+            start_http_server(port=config.metrics.port)
 
     if config.tracing is not None or config.metrics is not None:
         # FastAPI instrumentor reports both metrics and traces

--- a/aidial_sdk/telemetry/init.py
+++ b/aidial_sdk/telemetry/init.py
@@ -35,7 +35,6 @@ from opentelemetry.trace import set_tracer_provider
 from prometheus_client import start_http_server
 
 from aidial_sdk.telemetry.types import TelemetryConfig
-from aidial_sdk.utils.logging import logger
 
 
 def init_telemetry(
@@ -47,8 +46,6 @@ def init_telemetry(
             {SERVICE_NAME: config.service_name} if config.service_name else None
         )
     )
-
-    log_level = logger.getEffectiveLevel()
 
     if config.tracing is not None:
         tracer_provider = TracerProvider(resource=resource)
@@ -68,10 +65,7 @@ def init_telemetry(
         if config.tracing.logging:
             # Setting the root logger format in order to include
             # tracing information: span_id, trace_id
-            LoggingInstrumentor().instrument(
-                set_logging_format=True,
-                log_level=log_level,
-            )
+            LoggingInstrumentor().instrument(set_logging_format=True)
 
     if config.logs is not None:
         # Adding a handler to the root logger which exports the logs to OTLP
@@ -84,7 +78,7 @@ def init_telemetry(
 
         set_logger_provider(provider)
 
-        handler = LoggingHandler(level=log_level)
+        handler = LoggingHandler(level=config.logs.level)
         logging.getLogger().addHandler(handler)
 
     if config.metrics is not None:

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -4,7 +4,7 @@ from typing import Optional
 from aidial_sdk.pydantic_v1 import BaseModel
 from aidial_sdk.utils.env import env_var_list
 
-# Based on OpenTelemetry SDK env vars:
+# OpenTelemetry SDK configuration env vars:
 # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
 
 OTEL_LOGS_EXPORTER = env_var_list("OTEL_LOGS_EXPORTER")

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -3,11 +3,19 @@ from typing import Optional
 
 from aidial_sdk.pydantic_v1 import BaseModel
 
+# Variables borrowed from OpenTelemetry:
+# https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+
 OTEL_LOGS_EXPORTER = os.getenv("OTEL_LOGS_EXPORTER", "").split(",")
 OTEL_TRACES_EXPORTER = os.getenv("OTEL_TRACES_EXPORTER", "").split(",")
 OTEL_METRICS_EXPORTER = os.getenv("OTEL_METRICS_EXPORTER", "").split(",")
 OTEL_EXPORTER_PROMETHEUS_PORT = int(
     os.getenv("OTEL_EXPORTER_PROMETHEUS_PORT", 9464)
+)
+
+# DIAL-specific env vars
+DIAL_TELEMETRY_ADD_TRACES_TO_LOGS = (
+    os.getenv("DIAL_TELEMETRY_ADD_TRACES_TO_LOGS", "false").lower() == "true"
 )
 
 
@@ -18,8 +26,8 @@ class LogsConfig(BaseModel):
 class TracingConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_TRACES_EXPORTER
 
-    """Add tracing information to the console logs"""
-    logging: bool = False
+    """Configure logging to include tracing information into a log message"""
+    logging: bool = DIAL_TELEMETRY_ADD_TRACES_TO_LOGS
 
 
 class MetricsConfig(BaseModel):

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -14,11 +14,8 @@ OTEL_METRICS_EXPORTER = env_var_list("OTEL_METRICS_EXPORTER")
 OTEL_EXPORTER_PROMETHEUS_PORT = int(
     os.getenv("OTEL_EXPORTER_PROMETHEUS_PORT", 9464)
 )
-
-# DIAL-specific env vars
-OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES = (
-    os.getenv("OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES", "false").lower()
-    == "true"
+OTEL_PYTHON_LOG_CORRELATION = (
+    os.getenv("OTEL_PYTHON_LOG_CORRELATION", "false").lower() == "true"
 )
 
 
@@ -30,9 +27,9 @@ class LogsConfig(BaseModel):
 class TracingConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_TRACES_EXPORTER
 
-    """Configure logging to include tracing information
+    """Configure logging to include tracing context
     into console log messages"""
-    logging: bool = OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES
+    logging: bool = OTEL_PYTHON_LOG_CORRELATION
 
 
 class MetricsConfig(BaseModel):

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -4,6 +4,7 @@ from typing import Optional
 from aidial_sdk.pydantic_v1 import BaseModel
 from aidial_sdk.utils.env import env_var_list
 
+# Based on OpenTelemetry SDK env vars:
 # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
 
 OTEL_LOGS_EXPORTER = env_var_list("OTEL_LOGS_EXPORTER")
@@ -14,8 +15,9 @@ OTEL_EXPORTER_PROMETHEUS_PORT = int(
 )
 
 # DIAL-specific env vars
-DIAL_TELEMETRY_ADD_TRACES_TO_LOGS = (
-    os.getenv("DIAL_TELEMETRY_ADD_TRACES_TO_LOGS", "false").lower() == "true"
+OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES = (
+    os.getenv("OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES", "false").lower()
+    == "true"
 )
 
 
@@ -26,13 +28,16 @@ class LogsConfig(BaseModel):
 class TracingConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_TRACES_EXPORTER
 
-    """Configure logging to include tracing information into a log message"""
-    logging: bool = DIAL_TELEMETRY_ADD_TRACES_TO_LOGS
+    """Configure logging to include tracing information
+    into console log messages"""
+    logging: bool = OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES
 
 
 class MetricsConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_METRICS_EXPORTER
-    prometheus_export: bool = True
+    prometheus_export: bool = (
+        not OTEL_METRICS_EXPORTER or "prometheus" in OTEL_METRICS_EXPORTER
+    )
     port: int = OTEL_EXPORTER_PROMETHEUS_PORT
 
 

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Optional
 
@@ -23,6 +24,7 @@ OTEL_INSTRUMENT_CONSOLE_LOGS_WITH_TRACES = (
 
 class LogsConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_LOGS_EXPORTER
+    level: int = logging.INFO
 
 
 class TracingConfig(BaseModel):

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -1,18 +1,40 @@
+import os
 from typing import Optional
 
 from aidial_sdk.pydantic_v1 import BaseModel
 
+OTEL_LOGS_EXPORTER = os.getenv("OTEL_LOGS_EXPORTER", "").split(",")
+OTEL_TRACES_EXPORTER = os.getenv("OTEL_TRACES_EXPORTER", "").split(",")
+OTEL_METRICS_EXPORTER = os.getenv("OTEL_METRICS_EXPORTER", "").split(",")
+OTEL_EXPORTER_PROMETHEUS_PORT = int(
+    os.getenv("OTEL_EXPORTER_PROMETHEUS_PORT", 9464)
+)
+
+
+class LogsConfig(BaseModel):
+    otlp_export: bool = "otlp" in OTEL_LOGS_EXPORTER
+
 
 class TracingConfig(BaseModel):
-    otlp_export: bool = False
+    otlp_export: bool = "otlp" in OTEL_TRACES_EXPORTER
+
+    """Add tracing information to the console logs"""
     logging: bool = False
 
 
 class MetricsConfig(BaseModel):
-    port: int = 9464
+    otlp_export: bool = "otlp" in OTEL_METRICS_EXPORTER
+    prometheus_export: bool = True
+    port: int = OTEL_EXPORTER_PROMETHEUS_PORT
 
 
 class TelemetryConfig(BaseModel):
     service_name: Optional[str] = None
-    tracing: Optional[TracingConfig] = None
-    metrics: Optional[MetricsConfig] = None
+
+    logs: Optional[LogsConfig] = LogsConfig() if OTEL_LOGS_EXPORTER else None
+    tracing: Optional[TracingConfig] = (
+        TracingConfig() if OTEL_TRACES_EXPORTER else None
+    )
+    metrics: Optional[MetricsConfig] = (
+        MetricsConfig() if OTEL_METRICS_EXPORTER else None
+    )

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -2,13 +2,13 @@ import os
 from typing import Optional
 
 from aidial_sdk.pydantic_v1 import BaseModel
+from aidial_sdk.utils.env import env_var_list
 
-# Variables borrowed from OpenTelemetry:
 # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
 
-OTEL_LOGS_EXPORTER = os.getenv("OTEL_LOGS_EXPORTER", "").split(",")
-OTEL_TRACES_EXPORTER = os.getenv("OTEL_TRACES_EXPORTER", "").split(",")
-OTEL_METRICS_EXPORTER = os.getenv("OTEL_METRICS_EXPORTER", "").split(",")
+OTEL_LOGS_EXPORTER = env_var_list("OTEL_LOGS_EXPORTER")
+OTEL_TRACES_EXPORTER = env_var_list("OTEL_TRACES_EXPORTER")
+OTEL_METRICS_EXPORTER = env_var_list("OTEL_METRICS_EXPORTER")
 OTEL_EXPORTER_PROMETHEUS_PORT = int(
     os.getenv("OTEL_EXPORTER_PROMETHEUS_PORT", 9464)
 )

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -34,9 +34,7 @@ class TracingConfig(BaseModel):
 
 class MetricsConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_METRICS_EXPORTER
-    prometheus_export: bool = (
-        not OTEL_METRICS_EXPORTER or "prometheus" in OTEL_METRICS_EXPORTER
-    )
+    prometheus_export: bool = "prometheus" in OTEL_METRICS_EXPORTER
     port: int = OTEL_EXPORTER_PROMETHEUS_PORT
 
 

--- a/aidial_sdk/utils/env.py
+++ b/aidial_sdk/utils/env.py
@@ -1,0 +1,9 @@
+import os
+from typing import List
+
+
+def env_var_list(name: str) -> List[str]:
+    value = os.getenv(name)
+    if value is None:
+        return []
+    return value.split(",")


### PR DESCRIPTION
Breaking changes: the prometheus export is disabled by default. 

To enable it one needs to either:
1. manually set `prometheus_export=True` in `MetricsConfig`,
2. configure the export via `OTEL_METRICS_EXPORTER=prometheus` env var 