### PR TITLE
fix: residual index fields are moved in non-streaming mode

### DIFF
--- a/aidial_sdk/utils/streaming.py
+++ b/aidial_sdk/utils/streaming.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, AsyncGenerator, Dict
 
 from aidial_sdk.utils.logging import log_debug
-from aidial_sdk.utils.merge_chunks import merge
+from aidial_sdk.utils.merge_chunks import cleanup_indices, merge
 
 DONE_MARKER = "[DONE]"
 
@@ -15,7 +15,7 @@ async def merge_chunks(
         response = merge(response, chunk)
 
     for choice in response["choices"]:
-        choice["message"] = choice["delta"]
+        choice["message"] = cleanup_indices(choice["delta"])
         del choice["delta"]
 
     return response

--- a/tests/examples/test_echo.py
+++ b/tests/examples/test_echo.py
@@ -34,5 +34,4 @@ def test_app():
     assert response_content == content
 
     response_attachment = response_message["custom_content"]["attachments"][0]
-    del response_attachment["index"]
     assert response_attachment == attachment


### PR DESCRIPTION
`index` field must be removed in non-streaming mode. 
Note, that this is only applicable to `delta` field of a streaming chunk, because we want to preserve `choice.[*].index`.

Compare definitions of a tool call in streaming and non-streaming modes in `openai` lib.

streaming:

https://github.com/openai/openai-python/blob/254937a733b95366d21f5bda45b2f84693488e42/src/openai/types/chat/chat_completion_chunk.py#L47-L56

non-streaming:

https://github.com/openai/openai-python/blob/254937a733b95366d21f5bda45b2f84693488e42/src/openai/types/chat/chat_completion_message_tool_call.py#L23-L31