### PR TITLE
chore: enabled modern-installation in poetry

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,5 +1,2 @@
 [virtualenvs]
 in-project = true
-
-[installer]
-modern-installation = false


### PR DESCRIPTION
To avoid `poetry==1.8.3` complaining with the deprecation warning:

```
Warning: Setting `installer.modern-installation` to `false` is deprecated.
The pip-based installer will be removed in a future release.
See https://github.com/python-poetry/poetry/issues/8987.
```

See also [modern-installation](https://python-poetry.org/docs/configuration/#installermodern-installation) option in the Poetry docs.