### PR TITLE
feat: inherit all Enums from str to make JSON serialization possible

### DIFF
--- a/aidial_sdk/chat_completion/enums.py
+++ b/aidial_sdk/chat_completion/enums.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class FinishReason(Enum):
+class FinishReason(str, Enum):
     STOP = "stop"
     LENGTH = "length"
     FUNCTION_CALL = "function_call"
@@ -9,6 +9,6 @@ class FinishReason(Enum):
     CONTENT_FILTER = "content_filter"
 
 
-class Status(Enum):
+class Status(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -48,7 +48,7 @@ class ToolCall(ExtraForbidModel):
     function: FunctionCall
 
 
-class Role(Enum):
+class Role(str, Enum):
     SYSTEM = "system"
     USER = "user"
     ASSISTANT = "assistant"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,19 @@
+import json
+
+from aidial_sdk.chat_completion import Message, Role
+
+
+def test_message_ser():
+    msg_obj = Message(role=Role.SYSTEM, content="test")
+    actual_dict = msg_obj.dict(exclude_none=True)
+    expected_dict = {"role": "system", "content": "test"}
+
+    assert json.loads(json.dumps(actual_dict)) == expected_dict
+
+
+def test_message_deser():
+    msg_dict = {"role": "system", "content": "test"}
+    actual_obj = Message.parse_raw(json.dumps(msg_dict))
+    expected_obj = Message(role=Role.SYSTEM, content="test")
+
+    assert actual_obj == expected_obj


### PR DESCRIPTION
The following code throws an exception, because Enums aren't JSON serializable.
One needs to inherit Enum from str to make it work.

```python
import json
from aidial_sdk.chat_completion import Message, Role

msg = Message(role=Role.SYSTEM, content="test")
dict = msg.dict(exclude_none=True)
print(json.dumps(dict)) # exception: TypeError: Object of type Role is not JSON serializable
```

The pattern of converting DIAL messages to OpenAI message _(which is Python dict)_ is common in DIAL applications.
The exception doesn't allow to do it in a straigh-forward way and one have to resort to the hack like this:

```diff
import json
from aidial_sdk.chat_completion import Message, Role

msg = Message(role=Role.SYSTEM, content="test")
dict = msg.dict(exclude_none=True)
+ dict["role"] = dict["role"].value
print(json.dumps(dict)) # ok
```

The PR allows to avoid this hack.