### PR TITLE
feat: propagate Autorization header along with Api-Key header

### DIFF
--- a/tests/header_propagation/client.py
+++ b/tests/header_propagation/client.py
@@ -21,33 +21,35 @@ class Library(str, Enum):
 class Request(BaseModel):
     url: str
     lib: Library
+    headers: dict
 
 
 @app.post("/")
 async def handle(request: Request):
     url = request.url
     lib = request.lib
+    headers = request.headers
 
     if lib == Library.requests:
-        response = requests.get(url)
+        response = requests.get(url, headers=headers)
         status_code = response.status_code
         content = response.json()
 
     elif lib == Library.httpx_async:
         async with httpx.AsyncClient() as client:
-            response = await client.get(url)
+            response = await client.get(url, headers=headers)
             status_code = response.status_code
             content = response.json()
 
     elif lib == Library.httpx_sync:
         with httpx.Client() as client:
-            response = client.get(url)
+            response = client.get(url, headers=headers)
             status_code = response.status_code
             content = response.json()
 
     elif lib == Library.aiohttp:
         async with aiohttp.ClientSession() as session:
-            async with session.get(url) as response:
+            async with session.get(url, headers=headers) as response:
                 status_code = response.status
                 content = await response.json()
 


### PR DESCRIPTION
OpenAI library [sends](https://github.com/openai/openai-python/blob/ec4511a6fa4862770cf14b2b58d3493e9bacb062/tests/test_client.py#L1041-L1048) `Authorization` [header](https://github.com/openai/openai-python/blob/ec4511a6fa4862770cf14b2b58d3493e9bacb062/src/openai/_client.py#L366-L370) equal to `Bearer ${API_KEY}`, so that a request ends up having **two** auth-headers: `Api-Key` and `Authorization`. 

The DIAL Core fails if the headers are [inconsistent](https://github.com/epam/ai-dial-core/blob/37a5ed58d89f29fd0f2a9d1d57ae20c122c068d9/src/main/java/com/epam/aidial/core/Proxy.java#L162-L164). 

So we have to make them consistent in the header propagation logic.
