### PR TITLE
feat: added base64 str as embedding representation in the response

### DIFF
--- a/aidial_sdk/embeddings/response.py
+++ b/aidial_sdk/embeddings/response.py
@@ -14,11 +14,11 @@ class Usage(ExtraForbidModel):
     total_tokens: int
 
 
-class CreateEmbeddingResponse(ExtraForbidModel):
+class EmbeddingResponse(ExtraForbidModel):
     data: List[Embedding]
     model: str
     object: Literal["list"] = "list"
     usage: Usage
 
 
-Response = CreateEmbeddingResponse
+Response = EmbeddingResponse

--- a/aidial_sdk/embeddings/response.py
+++ b/aidial_sdk/embeddings/response.py
@@ -1,10 +1,10 @@
-from typing import List, Literal
+from typing import List, Literal, Union
 
 from aidial_sdk.utils.pydantic import ExtraForbidModel
 
 
 class Embedding(ExtraForbidModel):
-    embedding: List[float]
+    embedding: Union[str, List[float]]
     index: int
     object: Literal["embedding"] = "embedding"
 


### PR DESCRIPTION
As per [documentation](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-encoding_format), a base64-string is returned in embeddings response _(instead of a list of floats)_, when `request.encoding_format=base64`.