### PR TITLE
fix: restored removed auth headers

### DIFF
--- a/aidial_sdk/deployment/from_request_mixin.py
+++ b/aidial_sdk/deployment/from_request_mixin.py
@@ -6,6 +6,7 @@ import fastapi
 
 from aidial_sdk.exceptions import HTTPException as DIALException
 from aidial_sdk.pydantic_v1 import SecretStr, StrictStr, root_validator
+from aidial_sdk.utils._headers import hide_headers
 from aidial_sdk.utils.logging import log_debug
 from aidial_sdk.utils.pydantic import ExtraForbidModel
 
@@ -78,10 +79,8 @@ class FromRequestDeploymentMixin(FromRequestMixin):
                 type="invalid_request_error",
                 message="Api-Key header is required",
             )
-        del headers["Api-Key"]
 
         jwt = headers.get("Authorization")
-        del headers["Authorization"]
 
         return cls(
             **(await _get_request_body(request)),
@@ -89,7 +88,7 @@ class FromRequestDeploymentMixin(FromRequestMixin):
             jwt_secret=SecretStr(jwt) if jwt else None,
             deployment_id=deployment_id,
             api_version=request.query_params.get("api-version"),
-            headers=headers,
+            headers=hide_headers(headers, hidden=["Api-Key", "Authorization"]),
         )
 
 

--- a/aidial_sdk/utils/_headers.py
+++ b/aidial_sdk/utils/_headers.py
@@ -1,0 +1,19 @@
+from typing import List, Mapping
+
+
+def hide_headers(
+    obj: Mapping[str, str], hidden: List[str]
+) -> Mapping[str, str]:
+    hidden_set = {header.lower() for header in hidden}
+
+    def custom_str():
+        display_headers = {
+            k: ("**********" if k.lower() in hidden_set else v)
+            for k, v in obj.items()
+        }
+        return str(display_headers)
+
+    obj.__str__ = custom_str
+    obj.__repr__ = custom_str
+
+    return obj


### PR DESCRIPTION
https://github.com/epam/ai-dial-sdk/pull/123 has removed `api-key` and `authorization` from the request headers.

It breaks certain application which looks up `request.headers` for these auth header instread of using `request.api_key`.

The PR restores these headers and hides them from display at the same time.