### PR TITLE
fix: remove default for type field of the Attachment class

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -19,7 +19,7 @@ from aidial_sdk.utils.pydantic import ExtraForbidModel
 
 
 class Attachment(ExtraForbidModel):
-    type: Optional[StrictStr] = "text/markdown"
+    type: Optional[StrictStr] = None
     title: Optional[StrictStr] = None
     data: Optional[StrictStr] = None
     url: Optional[StrictStr] = None


### PR DESCRIPTION
The SDK defaults a missing `type` field to `text/markdown`:

https://github.com/epam/ai-dial-sdk/blob/2835107e950c89645a2b619fecba2518fa2d7bb1/aidial_sdk/chat_completion/request.py#L21-L27

This non-trivial default makes it impossible to receive attachments like this one:

```json
{ "url": "https://example.com/foo/bar/doc.pdf"}
```

Because it will be parsed to the object:

```python
Attachment(url="https://example.com/foo/bar/doc.pdf", type="text/markdown")
```

which is utterly bizarre and hard to deal with in the applications. 
See how it's worked around in the [adapter-bedrock](https://github.com/epam/ai-dial-adapter-bedrock/blob/71ee9b3b7cff4ce762aad66c74e75b6572522a1f/aidial_adapter_bedrock/dial_api/resource.py#L108-L117), likewise in [adapter-vertexai](https://github.com/epam/ai-dial-adapter-vertexai/blob/87f6c9684ec860c5e1a2e0329b1a91c6da06155f/aidial_adapter_vertexai/dial_api/resource.py#L108-L117).

Essentially, the parser from JSON to `Attachment`
1. reinterprets the data from the user as something that it isn't, and
2. obscures the data, because the downstream code doesn't see what exactly came in the request.

The proposal is to default to `None`.

On the other hand, SDK provides **inconsistent** ways to create `Attachment` objects.

See helpers at [aidial_sdk.utils._attachment](https://github.com/epam/ai-dial-sdk/blob/8abe5799cda7c121f70f314e8f5b769cdc500914/aidial_sdk/utils/_attachment.py):

```python
>>> print(create_attachment(Attachment()))
type='text/markdown' title=None data=None url=None reference_type=None reference_url=None
>>> print(create_attachment())
type=None title=None data=None url=None reference_type=None reference_url=None
```


