### PR TITLE
chore: bumped dependency versions in langchain_rag example

### DIFF
--- a/examples/langchain_rag/app.py
+++ b/examples/langchain_rag/app.py
@@ -16,6 +16,7 @@ from langchain_community.document_loaders import PyPDFLoader, WebBaseLoader
 from langchain_community.vectorstores import Chroma
 from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
+from pydantic import SecretStr
 from utils import get_last_attachment_url, sanitize_namespace
 
 from aidial_sdk import DIALApp
@@ -97,8 +98,8 @@ class SimpleRAGApplication(ChatCompletion):
                     azure_deployment=EMBEDDINGS_MODEL,
                     azure_endpoint=DIAL_URL,
                     # Header propagation automatically propagates the API key from the request headers.
-                    openai_api_key="-",
-                    openai_api_version=API_VERSION,
+                    api_key=SecretStr("-"),
+                    api_version=API_VERSION,
                     # The check leads to tokenization of the input strings.
                     # Tokenized input is only supported by OpenAI embedding models.
                     # For other models, the check should be disabled.
@@ -120,8 +121,8 @@ class SimpleRAGApplication(ChatCompletion):
                 azure_deployment=CHAT_MODEL,
                 azure_endpoint=DIAL_URL,
                 # Header propagation automatically propagates the API key from the request headers.
-                openai_api_key="-",
-                openai_api_version=API_VERSION,
+                api_key=SecretStr("-"),
+                api_version=API_VERSION,
                 temperature=0,
                 streaming=True,
                 callbacks=[CustomCallbackHandler(choice)],

--- a/examples/langchain_rag/requirements.txt
+++ b/examples/langchain_rag/requirements.txt
@@ -1,10 +1,10 @@
 aidial-sdk>=0.10
-langchain==0.2.10
-langchain-community==0.2.9
-langchain-openai==0.1.17
-langchain-text-splitters==0.2.2
+langchain==0.3.0
+langchain-community==0.3.0
+langchain-openai==0.2.6
+langchain-text-splitters==0.3.0
 tiktoken==0.7.0
-openai==1.35.15
+openai==1.54.0
 beautifulsoup4==4.12.3
 chromadb==0.5.4
 uvicorn==0.30.1


### PR DESCRIPTION
Subsumes https://github.com/epam/ai-dial-sdk/pull/178 and https://github.com/epam/ai-dial-sdk/pull/176