### PR TITLE
fix: fixed sharing issues in merge chunks algo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ format: install
 test: install
 	poetry run nox -s test $(if $(PYTHON),--python=$(PYTHON),)
 
+benchmark: install
+	python -m benchmark.benchmark_merge_chunks
+
 help:
 	@echo '===================='
 	@echo 'build                        - build the library'
@@ -36,3 +39,4 @@ help:
 	@echo '-- TESTS --'
 	@echo 'test                         - run unit tests'
 	@echo 'test PYTHON=<python_version> - run unit tests with the specific python version'
+	@echo 'benchmark                    - run benchmarks'

--- a/aidial_sdk/utils/merge_chunks.py
+++ b/aidial_sdk/utils/merge_chunks.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, List, TypeVar, Union, cast
 
 T = TypeVar("T")
@@ -90,7 +91,7 @@ def merge_indexed_lists(target: list, source: list, path: Path) -> list:
             target[index] = merge_recursive(target[index], elem, path)
         else:
             target.extend([{"index": idx} for idx in range(len(target), index)])
-            target.append(elem)
+            target.append(copy.deepcopy(elem))
 
         path.pop()
 
@@ -108,7 +109,7 @@ def merge_lists(target: list, source: list, path: Path) -> list:
         if is_source_indexed:
             return merge_indexed_lists(target, source, path)
         else:
-            return source
+            return copy.deepcopy(source)
 
     if not is_target_indexed and not is_source_indexed:
         raise AssertionError(CANNOT_MERGE_NON_INDEXED_LISTS_ERROR_MESSAGE)
@@ -121,6 +122,12 @@ def merge_lists(target: list, source: list, path: Path) -> list:
 
 
 def merge_recursive(target: T, source: Any, path: Path) -> T:
+    """
+    Recursively merging content of the source object into the target object.
+    The target object is modified in-place.
+    The source object is left unmodified.
+    """
+
     if source is None:
         return target
 
@@ -151,6 +158,13 @@ def merge_recursive(target: T, source: Any, path: Path) -> T:
 
 
 def merge(*chunks: T) -> T:
+    """
+    Merge a list of chunks into one.
+    The very first chunk is modified in-place by accumulating the content of the subsequent chunks.
+    The subsequent chunks aren't modified.
+    The new content added to the first chunk is deeply copied from a source chunk.
+    """
+
     assert len(chunks) > 0, "At least one chunk must be provided"
     ret: T = chunks[0]
     for chunk in chunks[1:]:
@@ -159,6 +173,11 @@ def merge(*chunks: T) -> T:
 
 
 def cleanup_indices(chunk: T) -> T:
+    """
+    Recursively remove all "index" fields inside list elements in the given chunk.
+    The chunk is modified in-place.
+    """
+
     if isinstance(chunk, list):
         ret = []
         for elem in chunk:

--- a/aidial_sdk/utils/merge_chunks.py
+++ b/aidial_sdk/utils/merge_chunks.py
@@ -193,3 +193,39 @@ def cleanup_indices(chunk: T) -> T:
         )
 
     return chunk
+
+
+_Chunk = TypeVar("_Chunk", bound=dict)
+
+
+def merge_chat_completion_chunks(*chunks: _Chunk) -> _Chunk:
+    """
+    The recursive merging procedure that avoids merging top-level atomic fields
+    (e.g. "id", "created", "model", "object", "system_fingerprint") and
+    instead chooses an _override_ merging strategy for such fields.
+    Non-atomic fields (e.g. "choice", "usage") are merged following
+    the standard recursive merging procedure.
+
+    The very first chunk is modified in-place.
+    The subsequent chunks are left unmodified.
+    """
+
+    assert (
+        len(chunks) > 0
+    ), "At least one chat completion chunk must be provided"
+
+    assert all(
+        isinstance(chunk, dict) for chunk in chunks
+    ), "The chat completion chunks are expected to be dictionaries"
+
+    target, *sources = chunks
+
+    for chunk in sources:
+        source = cast(_Chunk, chunk.copy())
+        for key, value in list(source.items()):
+            if not isinstance(value, (list, dict)) and value is not None:
+                target[key] = value
+                del source[key]
+        target = merge(target, source)
+
+    return target

--- a/tests/benchmark/benchmark_merge_chunks.py
+++ b/tests/benchmark/benchmark_merge_chunks.py
@@ -1,0 +1,143 @@
+import itertools
+import timeit
+from typing import Iterable, List
+
+from pydantic import BaseModel
+
+from aidial_sdk.utils.merge_chunks import merge_chat_completion_chunks
+from tests.utils.chunks import create_chunk
+
+
+def _interleave(*iters):
+    sentinel = object()
+    return [
+        elem
+        for tpl in itertools.zip_longest(*iters, fillvalue=sentinel)
+        for elem in tpl
+        if elem is not sentinel
+    ]
+
+
+class ChunkGenerator(BaseModel):
+    n_choices: int = 1
+    n_chunks_per_choice: int = 1
+    reversed_choices: bool = False
+    n_attachments_per_choice: int = 0
+    reversed_attachments: bool = False
+
+    @property
+    def desc(self) -> str:
+        r1 = "r" if self.reversed_choices else ""
+        r2 = "r" if self.reversed_attachments else ""
+        return f"{self.n_choices}{r1}x({self.n_chunks_per_choice}+{self.n_attachments_per_choice}{r2})"
+
+    def get_stream(self) -> Iterable[dict]:
+        def _range(n: int, rev: bool):
+            return reversed(range(n)) if rev else range(n)
+
+        def gen_content(choice_idx: int):
+            for chunk_idx in range(self.n_chunks_per_choice):
+                yield create_chunk(
+                    choice_idx=choice_idx,
+                    delta={"content": f"{chunk_idx} "},
+                )
+
+        def gen_attachments(choice_idx: int):
+            for attachment_idx in _range(
+                self.n_attachments_per_choice, self.reversed_attachments
+            ):
+                yield create_chunk(
+                    choice_idx=choice_idx,
+                    delta={
+                        "custom_content": {
+                            "attachments": [
+                                {
+                                    "index": attachment_idx,
+                                    "url": f"url{attachment_idx}",
+                                }
+                            ]
+                        }
+                    },
+                )
+
+        yield create_chunk(delta={"role": "assistant", "content": None})
+
+        for choice_idx in _range(self.n_choices, self.reversed_choices):
+            yield from _interleave(
+                gen_content(choice_idx),
+                gen_attachments(choice_idx),
+            )
+
+            yield create_chunk(choice_idx=choice_idx, finish_reason="stop")
+
+
+def benchmark(gen: ChunkGenerator, *, repeat: int, number: int | None = None):
+    def stmt():
+        merge_chat_completion_chunks({}, *gen.get_stream())
+
+    t = timeit.Timer(stmt=stmt)
+
+    if number is None:
+        number, _ = t.autorange()
+
+    timings = t.repeat(number=number, repeat=repeat)
+
+    best_sec = min(timings) / number
+    best_msec = best_sec * 1e3
+    best_usec = best_sec * 1e6
+
+    n_chunks = len(list(gen.get_stream()))
+
+    print(
+        ",".join(
+            [
+                gen.desc,
+                str(n_chunks),
+                str(number),
+                str(repeat),
+                f"{best_sec:.3f}",
+                f"{best_msec:.3f}",
+                f"{best_usec:.3f}",
+            ]
+        )
+    )
+
+
+base_case = ChunkGenerator(
+    n_choices=10,
+    reversed_choices=False,
+    n_chunks_per_choice=10,
+    n_attachments_per_choice=10,
+    reversed_attachments=False,
+)
+
+one_choice = base_case.model_copy(update={"n_choices": 1})
+
+cases: List[ChunkGenerator] = [
+    base_case,
+    base_case.model_copy(update={"n_choices": 20}),
+    base_case.model_copy(update={"n_chunks_per_choice": 20}),
+    base_case.model_copy(update={"n_attachments_per_choice": 20}),
+    base_case.model_copy(update={"reversed_choices": True}),
+    base_case.model_copy(update={"reversed_attachments": True}),
+    base_case.model_copy(
+        update={"reversed_choices": True, "reversed_attachments": True}
+    ),
+    one_choice.model_copy(
+        update={"n_chunks_per_choice": 0, "n_attachments_per_choice": 200}
+    ),
+    one_choice.model_copy(
+        update={"n_chunks_per_choice": 0, "n_attachments_per_choice": 400}
+    ),
+    one_choice.model_copy(
+        update={"n_chunks_per_choice": 200, "n_attachments_per_choice": 0}
+    ),
+    one_choice.model_copy(
+        update={"n_chunks_per_choice": 400, "n_attachments_per_choice": 0}
+    ),
+]
+
+if __name__ == "__main__":
+    print("Description,N chunks,Number,Repeats,Best sec,Best msec,Best usec")
+    for gen in cases:
+        benchmark(gen, repeat=10)

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -4,7 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from operator import attrgetter
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Union
+from typing import Any, Callable, Iterable, List, Sequence, Union
 
 import pytest
 
@@ -16,6 +16,7 @@ from aidial_sdk.utils.merge_chunks import (
     merge,
     merge_chat_completion_chunks,
 )
+from tests.utils.chunks import create_chunk
 from tests.utils.sharing import collect_shared_mutable_objects
 
 
@@ -267,23 +268,6 @@ merge_chunks_cases: List[Test] = [
         desc="Merge nested usage",
     ),
 ]
-
-
-def create_chunk(*, delta: dict = {}, finish_reason: Optional[str] = None):
-    return {
-        "id": "chatcmpl-AQws8iVykPBIQJfnmCQnMEkTLLUUA",
-        "object": "chat.completion.chunk",
-        "created": 1730986196,
-        "model": "gpt-4o-2024-05-13",
-        "system_fingerprint": "fp_67802d9a6d",
-        "choices": [
-            {
-                "index": 0,
-                "delta": delta,
-                "finish_reason": finish_reason,
-            }
-        ],
-    }
 
 
 OPEN_CHUNK = create_chunk(delta={"role": "assistant", "content": None})

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -35,11 +35,12 @@ class Fixed(OrderConstraint):
 
 
 @dataclass
-class BeforeElem(OrderConstraint):
+class BeforeValue(OrderConstraint):
     elem1: Any
     elem2: Any
 
     def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
+        # NOTE: it only works when elem1 and elem2 are unique elements in the sequence
         return seq.index(self.elem1) < seq.index(self.elem2)
 
 
@@ -49,7 +50,7 @@ class BeforeIdx(OrderConstraint):
     idx2: int
 
     def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
-        return BeforeElem(orig_seq[self.idx1], orig_seq[self.idx2]).satisfy(
+        return BeforeValue(orig_seq[self.idx1], orig_seq[self.idx2]).satisfy(
             orig_seq, seq
         )
 
@@ -79,7 +80,6 @@ class Test:
         self.order_constraints = order_constraints
 
     def permutations(self) -> Iterable["Test"]:
-
         if self.fixed_order:
             yield self
             return
@@ -359,7 +359,7 @@ merge_chat_completion_chunks_cases: List[Test] = [
     ),
     Test(
         chunks=[OPEN_CHUNK, CONTENT_CHUNK1, CONTENT_CHUNK2],
-        order_constraints=[BeforeElem(CONTENT_CHUNK1, CONTENT_CHUNK2)],
+        order_constraints=[BeforeValue(CONTENT_CHUNK1, CONTENT_CHUNK2)],
         expected=create_chunk(
             delta={"role": "assistant", "content": "hello world"}
         ),

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -1,8 +1,10 @@
 import copy
-import json
+import itertools
 import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, List, Set, Union
+from operator import attrgetter
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Union
 
 import pytest
 
@@ -12,10 +14,34 @@ from aidial_sdk.utils.merge_chunks import (
     INCONSISTENT_INDEXED_LIST_ERROR_MESSAGE,
     cleanup_indices,
     merge,
+    merge_chat_completion_chunks,
 )
+from tests.utils.sharing import collect_shared_mutable_objects
+
+
+class OrderConstraint(ABC):
+    @abstractmethod
+    def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
+        pass
 
 
 @dataclass
+class Fixed(OrderConstraint):
+    idx: int
+
+    def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
+        return orig_seq[self.idx] == seq[self.idx]
+
+
+@dataclass
+class Before(OrderConstraint):
+    elem1: Any
+    elem2: Any
+
+    def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
+        return seq.index(self.elem1) < seq.index(self.elem2)
+
+
 class Test:
     __test__ = False  # Hide from pytest test discovery
 
@@ -23,12 +49,62 @@ class Test:
     expected: Union[Any, Exception]
     desc: str
 
+    fixed_order: bool
+    order_constraints: List[OrderConstraint]
 
-test_cases: List[Test] = [
-    Test(chunks=[1, 2], expected=2, desc="Merge ints"),
-    Test(chunks=[1.0, 2.0], expected=2.0, desc="Merge floats"),
-    Test(chunks=["foo", "bar"], expected="foobar", desc="Merge strings"),
-    Test(chunks=[True, False], expected=False, desc="Merge bools"),
+    def __init__(
+        self,
+        chunks: List[Any],
+        expected: Any,
+        desc: str,
+        fixed_order: bool = False,
+        order_constraints: List[OrderConstraint] = [],
+    ):
+        self.chunks = copy.deepcopy(chunks)
+        self.expected = expected
+        self.desc = desc.replace(" ", "_").lower()
+        self.fixed_order = fixed_order
+        self.order_constraints = order_constraints
+
+    def permutations(self) -> Iterable["Test"]:
+
+        if self.fixed_order:
+            yield self
+            return
+
+        for idx, chunks in enumerate(itertools.permutations(self.chunks)):
+            if all(
+                c.satisfy(self.chunks, chunks) for c in self.order_constraints
+            ):
+                yield Test(
+                    chunks=list(chunks),
+                    expected=self.expected,
+                    desc=f"{self.desc} perm{idx}",
+                )
+
+
+def permute(cases: List[Test]) -> Iterable[Test]:
+    for case in cases:
+        yield from case.permutations()
+
+
+merge_chunks_cases: List[Test] = [
+    Test(chunks=[1, 2], expected=2, desc="Merge ints", fixed_order=True),
+    Test(
+        chunks=[1.0, 2.0], expected=2.0, desc="Merge floats", fixed_order=True
+    ),
+    Test(
+        chunks=["foo", "bar"],
+        expected="foobar",
+        desc="Merge strings",
+        fixed_order=True,
+    ),
+    Test(
+        chunks=[True, False],
+        expected=False,
+        desc="Merge bools",
+        fixed_order=True,
+    ),
     Test(chunks=[{}], expected={}, desc="Merge empty dicts"),
     Test(chunks=[1, None], expected=1, desc="Merge with None right"),
     Test(chunks=[None, 1], expected=1, desc="Merge with None left"),
@@ -41,6 +117,7 @@ test_cases: List[Test] = [
         expected=TypeError(
             "Cannot merge 'str' with incoming 'int' at path $.a.b"
         ),
+        fixed_order=True,
         desc="str+int type-error",
     ),
     Test(
@@ -48,6 +125,7 @@ test_cases: List[Test] = [
         expected=TypeError(
             "Cannot merge 'int' with incoming 'str' at path $.a.b"
         ),
+        fixed_order=True,
         desc="int+str type-error",
     ),
     Test(
@@ -68,6 +146,7 @@ test_cases: List[Test] = [
     Test(
         chunks=[{}, {"a": [{"index": 0}, {"value": 1}]}],
         expected=AssertionError(INCONSISTENT_INDEXED_LIST_ERROR_MESSAGE),
+        fixed_order=True,
         desc="Inconsistent list indexing",
     ),
     Test(
@@ -103,6 +182,7 @@ test_cases: List[Test] = [
         chunks=[{"a": 1, "b": 2}, {"c": 3, "b": 4}],
         expected={"a": 1, "b": 4, "c": 3},
         desc="Merge dicts with overlapping keys",
+        fixed_order=True,
     ),
     Test(
         chunks=[
@@ -110,6 +190,7 @@ test_cases: List[Test] = [
             {"a": [{"index": 0, "value": 2}]},
         ],
         expected={"a": [{"value": 2}]},
+        fixed_order=True,
         desc="Merge lists with overlapping indices",
     ),
     Test(
@@ -117,6 +198,7 @@ test_cases: List[Test] = [
             {"a": [{"index": 0, "value": 0}]},
             {"a": [{"index": 1, "value": 1}]},
         ],
+        fixed_order=True,
         expected={"a": [{"value": 0}, {"value": 1}]},
         desc="Merge lists with non-overlapping indices",
     ),
@@ -126,6 +208,7 @@ test_cases: List[Test] = [
             {"a": [{"index": 1, "value": 1}]},
             {"a": [{"index": 0, "value": 0}]},
         ],
+        order_constraints=[Fixed(0)],
         expected={"a": [{"value": 0}, {"value": 1}]},
         desc="Merge lists out-of-order",
     ),
@@ -147,6 +230,7 @@ test_cases: List[Test] = [
                 {"value": 5},
             ]
         },
+        order_constraints=[Fixed(0)],
         desc="Merge lists out-of-order (no starting point)",
     ),
     Test(
@@ -155,11 +239,13 @@ test_cases: List[Test] = [
             {"a": [{"index": 2, "value": 2}]},
         ],
         expected={"a": [{"value": 0}, {}, {"value": 2}]},
+        fixed_order=True,
         desc="Merge lists with a forward gap",
     ),
     Test(
         chunks=[{"a": "Hello "}, {"a": "world!"}],
         expected={"a": "Hello world!"},
+        fixed_order=True,
         desc="Merge nested strings",
     ),
     Test(
@@ -168,6 +254,7 @@ test_cases: List[Test] = [
             {"usage": {"prompt_tokens": 2}},
         ],
         expected={"usage": {"prompt_tokens": 2}},
+        fixed_order=True,
         desc="Merge top-level usage",
     ),
     Test(
@@ -176,18 +263,95 @@ test_cases: List[Test] = [
             {"a": {"usage": {"prompt_tokens": 2}}},
         ],
         expected={"a": {"usage": {"prompt_tokens": 2}}},
+        fixed_order=True,
         desc="Merge nested usage",
     ),
 ]
 
 
-@pytest.mark.parametrize("test", test_cases, ids=lambda t: t.desc)
+def create_chunk(*, delta: dict = {}, finish_reason: Optional[str] = None):
+    return {
+        "id": "chatcmpl-AQws8iVykPBIQJfnmCQnMEkTLLUUA",
+        "object": "chat.completion.chunk",
+        "created": 1730986196,
+        "model": "gpt-4o-2024-05-13",
+        "system_fingerprint": "fp_67802d9a6d",
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+
+
+OPEN_CHUNK = create_chunk(delta={"role": "assistant", "content": None})
+CONTENT_CHUNK1 = create_chunk(delta={"content": "hello"})
+CONTENT_CHUNK2 = create_chunk(delta={"content": " world"})
+
+merge_chat_completion_chunks_cases: List[Test] = [
+    Test(
+        chunks=[1, 2],
+        expected=Exception(
+            "The chat completion chunks are expected to be dictionaries"
+        ),
+        desc="Non-dict chunk",
+    ),
+    Test(
+        chunks=[],
+        expected=Exception(
+            "At least one chat completion chunk must be provided"
+        ),
+        desc="Zero chunks",
+    ),
+    Test(
+        chunks=[OPEN_CHUNK, {}],
+        expected=OPEN_CHUNK,
+        desc="Merge with empty dict",
+    ),
+    Test(
+        chunks=[OPEN_CHUNK, CONTENT_CHUNK1],
+        expected=create_chunk(delta={"role": "assistant", "content": "hello"}),
+        desc="Merge open with one content chunk",
+    ),
+    Test(
+        chunks=[OPEN_CHUNK, CONTENT_CHUNK1, CONTENT_CHUNK2],
+        order_constraints=[Before(CONTENT_CHUNK1, CONTENT_CHUNK2)],
+        expected=create_chunk(
+            delta={"role": "assistant", "content": "hello world"}
+        ),
+        desc="Merge open with two content chunks",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test", permute(merge_chunks_cases), ids=attrgetter("desc")
+)
 def test_merge_chunks(test: Test):
+    run_merge_test(test, merger=merge, remove_indices=True)
+
+
+@pytest.mark.parametrize(
+    "test", permute(merge_chat_completion_chunks_cases), ids=attrgetter("desc")
+)
+def test_merge_chat_completion_chunks(test: Test):
+    run_merge_test(
+        test, merger=merge_chat_completion_chunks, remove_indices=False
+    )
+
+
+def run_merge_test(
+    test: Test, *, merger: Callable[[Any], Any], remove_indices: bool
+):
     def _merge_chunks():
         old_chunks = [copy.deepcopy(chunk) for chunk in test.chunks]
         old_ids = [id(chunk) for chunk in test.chunks]
 
-        merged = cleanup_indices(merge(*test.chunks))
+        merged = merger(*test.chunks)
+        if remove_indices:
+            merged = cleanup_indices(merged)
 
         new_chunks = test.chunks
         new_ids = [id(chunk) for chunk in test.chunks]
@@ -210,42 +374,3 @@ def test_merge_chunks(test: Test):
             _merge_chunks()
     else:
         assert _merge_chunks() == test.expected
-
-
-class IdHashable:
-    obj: Any
-
-    def __init__(self, obj: Any) -> None:
-        self.obj = obj
-
-    def __hash__(self):
-        return id(self.obj)
-
-    def __eq__(self, other: object) -> bool:
-        return (type(self), hash(self)) == (type(other), hash(other))
-
-    def __repr__(self):
-        return json.dumps(self.obj)
-
-
-def collect_mutable_objects(a: Any) -> Set[IdHashable]:
-    ret: set[IdHashable] = set()
-
-    def _register(obj: Any):
-        if isinstance(obj, (dict, list, tuple)):
-            ret.add(IdHashable(obj))
-
-    def _rec(obj: Any):
-        _register(obj)
-        if isinstance(obj, dict):
-            list(map(_rec, obj.values()))
-        elif isinstance(obj, (list, tuple)):
-            list(map(_rec, obj))
-
-    _rec(a)
-
-    return ret
-
-
-def collect_shared_mutable_objects(a: Any, b: Any) -> Set[IdHashable]:
-    return collect_mutable_objects(a) & collect_mutable_objects(b)

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -135,6 +135,14 @@ merge_chunks_cases: List[Test] = [
         desc="str+int type-error",
     ),
     Test(
+        chunks=[{"a": ("foo", "bar")}, {"a": ("baz", "quz")}],
+        expected=TypeError(
+            "Cannot merge 'tuple' with incoming 'tuple' at path $.a"
+        ),
+        fixed_order=True,
+        desc="tuple+tuple type-error",
+    ),
+    Test(
         chunks=[{"a": {"b": 1}}, {"a": {"b": "foo"}}],
         expected=TypeError(
             "Cannot merge 'int' with incoming 'str' at path $.a.b"
@@ -281,6 +289,42 @@ merge_chunks_cases: List[Test] = [
         desc="Merge nested usage",
     ),
 ]
+
+
+def test_deep_copy_for_non_indexed_lists():
+    chunk_actual = {"list": [{"content": "hello"}]}
+    chunk_expected = copy.deepcopy(chunk_actual)
+
+    chunk = {}
+    chunk = merge(chunk, chunk_actual)
+    chunk["list"][0]["content"] += " world"
+
+    assert chunk_actual == chunk_expected
+    assert chunk == {"list": [{"content": "hello world"}]}
+
+
+def test_deep_copy_for_indexed_lists():
+    chunk_actual = {"list": [{"index": 0, "content": "hello"}]}
+    chunk_expected = copy.deepcopy(chunk_actual)
+
+    chunk = {}
+    chunk = merge(chunk, chunk_actual)
+    chunk = merge(chunk, {"list": [{"index": 0, "content": " world"}]})
+
+    assert chunk_actual == chunk_expected
+    assert chunk == {"list": [{"index": 0, "content": "hello world"}]}
+
+
+def test_deep_copy_for_dict_values():
+    chunk_actual = {"a": {}}
+    chunk_expected = copy.deepcopy(chunk_actual)
+
+    chunk = {}
+    chunk = merge(chunk, chunk_actual)
+    chunk = merge(chunk, {"a": {"b": "c"}})
+
+    assert chunk_actual == chunk_expected
+    assert chunk == {"a": {"b": "c"}}
 
 
 OPEN_CHUNK = create_chunk(delta={"role": "assistant", "content": None})

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -1,6 +1,8 @@
+import copy
+import json
 import re
 from dataclasses import dataclass
-from typing import Any, List, Union
+from typing import Any, List, Set, Union
 
 import pytest
 
@@ -181,10 +183,69 @@ test_cases: List[Test] = [
 
 @pytest.mark.parametrize("test", test_cases, ids=lambda t: t.desc)
 def test_merge_chunks(test: Test):
+    def _merge_chunks():
+        old_chunks = [copy.deepcopy(chunk) for chunk in test.chunks]
+        old_ids = [id(chunk) for chunk in test.chunks]
+
+        merged = cleanup_indices(merge(*test.chunks))
+
+        new_chunks = test.chunks
+        new_ids = [id(chunk) for chunk in test.chunks]
+
+        assert old_chunks[1:] == new_chunks[1:]
+        assert old_ids[1:] == new_ids[1:]
+
+        for new_chunk in new_chunks[1:]:
+            assert (
+                collect_shared_mutable_objects(new_chunks[0], new_chunk)
+                == set()
+            )
+
+        return merged
+
     if isinstance(test.expected, Exception):
         with pytest.raises(
             type(test.expected), match=re.escape(str(test.expected))
         ):
-            cleanup_indices(merge(*test.chunks))
+            _merge_chunks()
     else:
-        assert cleanup_indices(merge(*test.chunks)) == test.expected
+        assert _merge_chunks() == test.expected
+
+
+class IdHashable:
+    obj: Any
+
+    def __init__(self, obj: Any) -> None:
+        self.obj = obj
+
+    def __hash__(self):
+        return id(self.obj)
+
+    def __eq__(self, other: object) -> bool:
+        return (type(self), hash(self)) == (type(other), hash(other))
+
+    def __repr__(self):
+        return json.dumps(self.obj)
+
+
+def collect_mutable_objects(a: Any) -> Set[IdHashable]:
+    ret: set[IdHashable] = set()
+
+    def _register(obj: Any):
+        if isinstance(obj, (dict, list, tuple)):
+            ret.add(IdHashable(obj))
+
+    def _rec(obj: Any):
+        _register(obj)
+        if isinstance(obj, dict):
+            list(map(_rec, obj.values()))
+        elif isinstance(obj, (list, tuple)):
+            list(map(_rec, obj))
+
+    _rec(a)
+
+    return ret
+
+
+def collect_shared_mutable_objects(a: Any, b: Any) -> Set[IdHashable]:
+    return collect_mutable_objects(a) & collect_mutable_objects(b)

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -16,7 +16,7 @@ from aidial_sdk.utils.merge_chunks import (
     merge,
     merge_chat_completion_chunks,
 )
-from tests.utils.chunks import create_chunk
+from tests.utils.chunks import create_chunk, create_tool_call_chunk
 from tests.utils.sharing import collect_shared_mutable_objects
 
 
@@ -35,12 +35,23 @@ class Fixed(OrderConstraint):
 
 
 @dataclass
-class Before(OrderConstraint):
+class BeforeElem(OrderConstraint):
     elem1: Any
     elem2: Any
 
     def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
         return seq.index(self.elem1) < seq.index(self.elem2)
+
+
+@dataclass
+class BeforeIdx(OrderConstraint):
+    idx1: int
+    idx2: int
+
+    def satisfy(self, orig_seq: Sequence[Any], seq: Sequence[Any]) -> bool:
+        return BeforeElem(orig_seq[self.idx1], orig_seq[self.idx2]).satisfy(
+            orig_seq, seq
+        )
 
 
 class Test:
@@ -73,14 +84,16 @@ class Test:
             yield self
             return
 
-        for idx, chunks in enumerate(itertools.permutations(self.chunks)):
+        n = len(self.chunks)
+        for indices in itertools.permutations(range(n)):
+            chunks = [self.chunks[idx] for idx in indices]
             if all(
                 c.satisfy(self.chunks, chunks) for c in self.order_constraints
             ):
                 yield Test(
                     chunks=list(chunks),
                     expected=self.expected,
-                    desc=f"{self.desc} perm{idx}",
+                    desc=f"{self.desc} {' '.join(map(str, indices))}",
                 )
 
 
@@ -274,6 +287,7 @@ OPEN_CHUNK = create_chunk(delta={"role": "assistant", "content": None})
 CONTENT_CHUNK1 = create_chunk(delta={"content": "hello"})
 CONTENT_CHUNK2 = create_chunk(delta={"content": " world"})
 
+
 merge_chat_completion_chunks_cases: List[Test] = [
     Test(
         chunks=[1, 2],
@@ -301,11 +315,54 @@ merge_chat_completion_chunks_cases: List[Test] = [
     ),
     Test(
         chunks=[OPEN_CHUNK, CONTENT_CHUNK1, CONTENT_CHUNK2],
-        order_constraints=[Before(CONTENT_CHUNK1, CONTENT_CHUNK2)],
+        order_constraints=[BeforeElem(CONTENT_CHUNK1, CONTENT_CHUNK2)],
         expected=create_chunk(
             delta={"role": "assistant", "content": "hello world"}
         ),
         desc="Merge open with two content chunks",
+    ),
+    Test(
+        chunks=[
+            OPEN_CHUNK,  # 0
+            create_chunk(delta={"content": "sure, I'm calling the tools"}),  # 1
+            create_tool_call_chunk(
+                0,
+                id="tool_call_1",
+                name="get_weather",
+                type="function",
+            ),  # 2
+            create_tool_call_chunk(0, arguments='{"cit'),  # 3
+            create_tool_call_chunk(0, arguments='y": "London"}'),  # 4
+            create_tool_call_chunk(
+                1, id="tool_call_2", name="get_time", type="function"
+            ),  # 5
+            create_tool_call_chunk(1, arguments="{}"),  # 6
+        ],
+        order_constraints=[Fixed(0), BeforeIdx(3, 4)],
+        expected=create_chunk(
+            delta={
+                "role": "assistant",
+                "content": "sure, I'm calling the tools",
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "tool_call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "London"}',
+                        },
+                    },
+                    {
+                        "index": 1,
+                        "id": "tool_call_2",
+                        "type": "function",
+                        "function": {"name": "get_time", "arguments": "{}"},
+                    },
+                ],
+            }
+        ),
+        desc="Merge with tool calls",
     ),
 ]
 

--- a/tests/utils/chunks.py
+++ b/tests/utils/chunks.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from typing import Literal, Optional
 
 
 def create_chunk(
     *,
     choice_idx: int = 0,
     delta: dict = {},
-    finish_reason: Optional[str] = None
+    finish_reason: Optional[str] = None,
 ):
     return {
         "id": "chatcmpl-AQws8iVykPBIQJfnmCQnMEkTLLUUA",
@@ -21,3 +21,25 @@ def create_chunk(
             }
         ],
     }
+
+
+def create_tool_call_chunk(
+    idx: int,
+    *,
+    type: Optional[Literal["function"]] = None,
+    id: Optional[str] = None,
+    name: Optional[str] = None,
+    arguments: Optional[str] = None,
+):
+    return create_chunk(
+        delta={
+            "tool_calls": [
+                {
+                    "index": idx,
+                    "id": id,
+                    "type": type,
+                    "function": {"name": name, "arguments": arguments},
+                }
+            ]
+        }
+    )

--- a/tests/utils/chunks.py
+++ b/tests/utils/chunks.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+
+def create_chunk(
+    *,
+    choice_idx: int = 0,
+    delta: dict = {},
+    finish_reason: Optional[str] = None
+):
+    return {
+        "id": "chatcmpl-AQws8iVykPBIQJfnmCQnMEkTLLUUA",
+        "object": "chat.completion.chunk",
+        "created": 1730986196,
+        "model": "gpt-4o-2024-05-13",
+        "system_fingerprint": "fp_67802d9a6d",
+        "choices": [
+            {
+                "index": choice_idx,
+                "delta": delta,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }

--- a/tests/utils/sharing.py
+++ b/tests/utils/sharing.py
@@ -22,7 +22,7 @@ def collect_mutable_objects(a: Any) -> Set[IdHashable]:
     ret: set[IdHashable] = set()
 
     def _register(obj: Any):
-        if isinstance(obj, (dict, list, tuple)):
+        if isinstance(obj, (dict, list)):
             ret.add(IdHashable(obj))
 
     def _rec(obj: Any):

--- a/tests/utils/sharing.py
+++ b/tests/utils/sharing.py
@@ -1,0 +1,41 @@
+import json
+from typing import Any, Set
+
+
+class IdHashable:
+    obj: Any
+
+    def __init__(self, obj: Any) -> None:
+        self.obj = obj
+
+    def __hash__(self):
+        return id(self.obj)
+
+    def __eq__(self, other: object) -> bool:
+        return (type(self), hash(self)) == (type(other), hash(other))
+
+    def __repr__(self):
+        return json.dumps(self.obj)
+
+
+def collect_mutable_objects(a: Any) -> Set[IdHashable]:
+    ret: set[IdHashable] = set()
+
+    def _register(obj: Any):
+        if isinstance(obj, (dict, list, tuple)):
+            ret.add(IdHashable(obj))
+
+    def _rec(obj: Any):
+        _register(obj)
+        if isinstance(obj, dict):
+            list(map(_rec, obj.values()))
+        elif isinstance(obj, (list, tuple)):
+            list(map(_rec, obj))
+
+    _rec(a)
+
+    return ret
+
+
+def collect_shared_mutable_objects(a: Any, b: Any) -> Set[IdHashable]:
+    return collect_mutable_objects(a) & collect_mutable_objects(b)


### PR DESCRIPTION
The merge chunks algorithm transferred objects from the sources to the target, which may lead to corruption of sources in the follow-up merges. The fix is to do a deep copy when needed to ensure that the target and sources do not share any objects.

The other changes in the code:
1. added tests to witness the bug fix;
2. introduced merge algo for chat completion chunks, and added tests for it;
3. added code for benchmarking merge chunks algorithm.

Benchmarking of `merge_chat_completion_chunks` method showed slowdown because of the introduced deep copy, which is to be expected.

| Description     | N chunks | Number | Repeats | Best usec (before) | Best usec (after) | Slowdown (%)    |
|-----------------|----------|--------|---------|--------------------|-------------------|-----------------|
| 10x(10+10)      | 211      | 500    | 10      | 797.526           | 945.159          | 18.51137142     |
| 20x(10+10)      | 421      | 200    | 10      | 1640.433          | 1941.294         | 18.34034063     |
| 10x(20+10)      | 311      | 200    | 10      | 1144.313          | 1271.568         | 11.12064619     |
| 10x(10+20)      | 311      | 200    | 10      | 1264.515          | 1531.074         | 21.07993974     |
| 10rx(10+10)     | 211      | 500    | 10      | 833.442           | 958.101          | 14.95712959     |
| 10x(10+10r)     | 211      | 500    | 10      | 840.902           | 865.305          | 2.902002849     |
| 10rx(10+10r)    | 211      | 500    | 10      | 879.949           | 879.439          | -0.057957904    |
| 1x(0+200)       | 202      | 200    | 10      | 1381.09           | 1658.863         | 20.11259223     |
| 1x(0+400)       | 402      | 50     | 10      | 3958.811          | 4561.656         | 15.22793081     |
| 1x(200+0)       | 202      | 500    | 10      | 659.785           | 661.718          | 0.292974226     |
| 1x(400+0)       | 402      | 200    | 10      | 1306.368          | 1321.479         | 1.156718474     |
