### PR TITLE
fix: support conditional imports of http libraries

### DIFF
--- a/aidial_sdk/chat_completion/response.py
+++ b/aidial_sdk/chat_completion/response.py
@@ -112,7 +112,20 @@ class Response:
                     and chunk.choice_index == self.n - 1
                 )
 
-                is_top_level_chunk = isinstance(
+                # It's not clear if a chunk without
+                # a missing `choices` field (or a empty list for `choices`)
+                # will be parsed correctly downstream.
+                # To eliminate choiceless chunks altogether we
+                # (1) delay their sending until the very last moment and
+                # (2) merge them with the final choice closing chunk, so
+                #     there will be at least one choice attached to
+                #     this combined chunk.
+                # The alternatives:
+                #   (1) to send the choiceless chunks with a choice containing empty content or
+                #   (2) allow sending chunks with an empty list of choices.
+                #       After all stream_options.include_usage=True leads to
+                #       creation of such a chunk.
+                is_choiceless_chunk = isinstance(
                     chunk,
                     (
                         UsageChunk,
@@ -121,7 +134,7 @@ class Response:
                     ),
                 )
 
-                if is_last_end_choice_chunk or is_top_level_chunk:
+                if is_last_end_choice_chunk or is_choiceless_chunk:
                     delayed_chunks.append(chunk)
                 else:
                     yield _create_chunk(chunk)

--- a/aidial_sdk/chat_completion/response.py
+++ b/aidial_sdk/chat_completion/response.py
@@ -112,20 +112,7 @@ class Response:
                     and chunk.choice_index == self.n - 1
                 )
 
-                # It's not clear if a chunk without
-                # a missing `choices` field (or a empty list for `choices`)
-                # will be parsed correctly downstream.
-                # To eliminate choiceless chunks altogether we
-                # (1) delay their sending until the very last moment and
-                # (2) merge them with the final choice closing chunk, so
-                #     there will be at least one choice attached to
-                #     this combined chunk.
-                # The alternatives:
-                #   (1) to send the choiceless chunks with a choice containing empty content or
-                #   (2) allow sending chunks with an empty list of choices.
-                #       After all stream_options.include_usage=True leads to
-                #       creation of such a chunk.
-                is_choiceless_chunk = isinstance(
+                is_top_level_chunk = isinstance(
                     chunk,
                     (
                         UsageChunk,
@@ -134,7 +121,7 @@ class Response:
                     ),
                 )
 
-                if is_last_end_choice_chunk or is_choiceless_chunk:
+                if is_last_end_choice_chunk or is_top_level_chunk:
                     delayed_chunks.append(chunk)
                 else:
                     yield _create_chunk(chunk)

--- a/aidial_sdk/header_propagator.py
+++ b/aidial_sdk/header_propagator.py
@@ -2,12 +2,11 @@ import types
 from contextvars import ContextVar
 from typing import MutableMapping, Optional
 
-import aiohttp
-import httpx
-import requests
 import wrapt
 from fastapi import FastAPI
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+from aidial_sdk.utils.logging import log_debug
 
 
 class FastAPIMiddleware:
@@ -59,9 +58,24 @@ class HeaderPropagator:
         app.add_middleware(FastAPIMiddleware, api_key=self._api_key)
 
     def _instrument_aiohttp(self):
+        try:
+            import aiohttp
+        except ImportError:
+            log_debug(
+                "aiohttp package isn't installed. Skipping the instrumentation."
+            )
+            return
+
+        async def _request_start(
+            session: aiohttp.ClientSession,
+            trace_config_ctx: types.SimpleNamespace,
+            params: aiohttp.TraceRequestStartParams,
+        ):
+            self._modify_headers(str(params.url), params.headers)
+
         def instrumented_init(wrapped, instance, args, kwargs):
             trace_config = aiohttp.TraceConfig()
-            trace_config.on_request_start.append(self._on_aiohttp_request_start)
+            trace_config.on_request_start.append(_request_start)
 
             trace_configs = list(kwargs.get("trace_configs") or [])
             trace_configs.append(trace_config)
@@ -73,15 +87,15 @@ class HeaderPropagator:
             aiohttp.ClientSession, "__init__", instrumented_init
         )
 
-    async def _on_aiohttp_request_start(
-        self,
-        session: aiohttp.ClientSession,
-        trace_config_ctx: types.SimpleNamespace,
-        params: aiohttp.TraceRequestStartParams,
-    ):
-        self._modify_headers(str(params.url), params.headers)
-
     def _instrument_requests(self):
+        try:
+            import requests
+        except ImportError:
+            log_debug(
+                "requests package isn't installed. Skipping the instrumentation."
+            )
+            return
+
         def instrumented_send(wrapped, instance, args, kwargs):
             request: requests.PreparedRequest = args[0]
             self._modify_headers(request.url or "", request.headers)
@@ -90,6 +104,13 @@ class HeaderPropagator:
         wrapt.wrap_function_wrapper(requests.Session, "send", instrumented_send)
 
     def _instrument_httpx(self):
+        try:
+            import httpx
+        except ImportError:
+            log_debug(
+                "httpx package isn't installed. Skipping the instrumentation."
+            )
+            return
 
         def instrumented_build_request(wrapped, instance, args, kwargs):
             request: httpx.Request = wrapped(*args, **kwargs)

--- a/aidial_sdk/header_propagator.py
+++ b/aidial_sdk/header_propagator.py
@@ -6,8 +6,6 @@ import wrapt
 from fastapi import FastAPI
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from aidial_sdk.utils.logging import log_debug
-
 
 class FastAPIMiddleware:
     def __init__(
@@ -61,9 +59,6 @@ class HeaderPropagator:
         try:
             import aiohttp
         except ImportError:
-            log_debug(
-                "aiohttp package isn't installed. Skipping the instrumentation."
-            )
             return
 
         async def _request_start(
@@ -91,9 +86,6 @@ class HeaderPropagator:
         try:
             import requests
         except ImportError:
-            log_debug(
-                "requests package isn't installed. Skipping the instrumentation."
-            )
             return
 
         def instrumented_send(wrapped, instance, args, kwargs):
@@ -107,9 +99,6 @@ class HeaderPropagator:
         try:
             import httpx
         except ImportError:
-            log_debug(
-                "httpx package isn't installed. Skipping the instrumentation."
-            )
             return
 
         def instrumented_build_request(wrapped, instance, args, kwargs):

--- a/aidial_sdk/header_propagator.py
+++ b/aidial_sdk/header_propagator.py
@@ -61,7 +61,7 @@ class HeaderPropagator:
         except ImportError:
             return
 
-        async def _request_start(
+        async def _on_request_start(
             session: aiohttp.ClientSession,
             trace_config_ctx: types.SimpleNamespace,
             params: aiohttp.TraceRequestStartParams,
@@ -70,7 +70,7 @@ class HeaderPropagator:
 
         def instrumented_init(wrapped, instance, args, kwargs):
             trace_config = aiohttp.TraceConfig()
-            trace_config.on_request_start.append(_request_start)
+            trace_config.on_request_start.append(_on_request_start)
 
             trace_configs = list(kwargs.get("trace_configs") or [])
             trace_configs.append(trace_config)

--- a/aidial_sdk/telemetry/init.py
+++ b/aidial_sdk/telemetry/init.py
@@ -10,13 +10,8 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
 )
 from opentelemetry.exporter.prometheus import PrometheusMetricReader
-from opentelemetry.instrumentation.aiohttp_client import (
-    AioHttpClientInstrumentor,
-)
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
-from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.system_metrics import (
     SystemMetricsInstrumentor,
 )
@@ -57,10 +52,34 @@ def init_telemetry(
 
         set_tracer_provider(tracer_provider)
 
-        RequestsInstrumentor().instrument()
-        AioHttpClientInstrumentor().instrument()
+        try:
+            from opentelemetry.instrumentation.requests import (
+                RequestsInstrumentor,
+            )
+
+            RequestsInstrumentor().instrument()
+        except ImportError:
+            pass
+
+        try:
+            from opentelemetry.instrumentation.aiohttp_client import (
+                AioHttpClientInstrumentor,
+            )
+
+            AioHttpClientInstrumentor().instrument()
+        except ImportError:
+            pass
+
         URLLibInstrumentor().instrument()
-        HTTPXClientInstrumentor().instrument()
+
+        try:
+            from opentelemetry.instrumentation.httpx import (
+                HTTPXClientInstrumentor,
+            )
+
+            HTTPXClientInstrumentor().instrument()
+        except ImportError:
+            pass
 
         if config.tracing.logging:
             # Setting the root logger format in order to include

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,6 +40,8 @@ def format(session: nox.Session):
 def test(session: nox.Session, pydantic: str, httpx: str) -> None:
     """Runs tests"""
     session.run("poetry", "install", external=True)
-    session.install(f"pydantic=={pydantic}")
-    session.install(f"httpx=={httpx}")
+    session.install(
+        f"pydantic=={pydantic}",
+        f"httpx=={httpx}",
+    )
     session.run("pytest")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1827,7 +1827,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2255,4 +2254,4 @@ telemetry = ["opentelemetry-api", "opentelemetry-distro", "opentelemetry-exporte
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "331cb288266a26b7c14ae771d6e0409ba4d911c648b7e608b0da9d0af0d0c090"
+content-hash = "04514235426dad72f5368517a74020c5a401de566fbdd3805cde17387ad9725e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ wrapt = ">=1.10,<2"
 opentelemetry-sdk = {version = "1.20.0", optional = true}
 opentelemetry-api = {version = "1.20.0", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.20.0", optional = true}
-opentelemetry-distro ={version = "0.41b0", optional = true}
+opentelemetry-distro = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation-aiohttp-client = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation-fastapi = {version = "0.41b0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ wrapt = ">=1.10,<2"
 opentelemetry-sdk = {version = "1.20.0", optional = true}
 opentelemetry-api = {version = "1.20.0", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.20.0", optional = true}
-opentelemetry-distro = {version = "0.41b0", optional = true}
+opentelemetry-distro ={version = "0.41b0", optional = true}
 opentelemetry-instrumentation = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation-aiohttp-client = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation-fastapi = {version = "0.41b0", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,7 @@ python = ">=3.8.1,<4.0"
 fastapi = ">=0.51,<1.0"
 uvicorn = ">=0.19,<1.0"
 pydantic = ">=1.10,<3"
-requests = "^2.19"
-wrapt = "^1.14"
-aiohttp = "^3.8.3"
-httpx = ">=0.25.0,<1.0"
+wrapt = ">=1.10,<2"
 opentelemetry-sdk = {version = "1.20.0", optional = true}
 opentelemetry-api = {version = "1.20.0", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.20.0", optional = true}
@@ -55,8 +52,11 @@ pytest = "^8.2"
 pytest-asyncio = "^0.24.0"
 nox = "^2023.4.22"
 pillow = "^10.2.0"
+httpx = "^0.25.0"
 respx = "^0.21.1"
+aiohttp = "^3.8.3"
 aioresponses = "^0.7.6"
+requests = "^2.19"
 responses = "^0.25.3"
 
 [tool.poetry.group.lint.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ httpx = ">=0.25.0,<1.0"
 opentelemetry-sdk = {version = "1.20.0", optional = true}
 opentelemetry-api = {version = "1.20.0", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = "1.20.0", optional = true}
-opentelemetry-distro ={version =  "0.41b0", optional = true}
+opentelemetry-distro ={version = "0.41b0", optional = true}
 opentelemetry-instrumentation = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation-aiohttp-client = {version = "0.41b0", optional = true}
 opentelemetry-instrumentation-fastapi = {version = "0.41b0", optional = true}


### PR DESCRIPTION
Resolves #62 

HTTP client libraries (`requests`, `aiohttp` and `httpx`) were removed from the list of SDK dependencies.