### PR TITLE
chore: add missing dependencies in examples

### DIFF
--- a/examples/echo/requirements.txt
+++ b/examples/echo/requirements.txt
@@ -1,1 +1,2 @@
 aidial-sdk>=0.10
+uvicorn==0.30.1

--- a/examples/image_size/requirements.txt
+++ b/examples/image_size/requirements.txt
@@ -1,3 +1,4 @@
 aidial-sdk>=0.10
 pillow==10.3.0
 aiohttp==3.10.11
+uvicorn==0.30.1

--- a/examples/langchain_rag/requirements.txt
+++ b/examples/langchain_rag/requirements.txt
@@ -5,6 +5,7 @@ langchain-openai==0.2.6
 langchain-text-splitters==0.3.0
 tiktoken==0.7.0
 openai==1.54.0
+httpx==0.27.2
 beautifulsoup4==4.12.3
 chromadb==0.5.4
 uvicorn==0.30.1

--- a/examples/render_text/requirements.txt
+++ b/examples/render_text/requirements.txt
@@ -1,3 +1,4 @@
 aidial-sdk>=0.10
 pillow==10.3.0
 aiohttp==3.10.11
+uvicorn==0.30.1


### PR DESCRIPTION
1. Added `uvicorn` and `aiohttp` as explicit dependencies where needed
2. Pinned `httpx==0.27.2` since the Python packages `httpx>=0.28` and `openai<1.55.3` are incompatbile. The fix is either to downgrade `httpx` to (<0.28) or upgrade `openai` to >=1.55.3. See https://github.com/openai/openai-python/pull/1904 for the details.