### PR TITLE
feat: Added support for application type schemas 

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -205,6 +205,7 @@ class ChatCompletionRequest(AzureChatCompletionRequest):
     addons: Optional[List[Addon]] = None
     max_prompt_tokens: Optional[PositiveInt] = None
     custom_fields: Optional[ChatCompletionRequestCustomFields] = None
+    custom_application_properties: Optional[Dict[str, Any]] = None
 
 
 class Request(ChatCompletionRequest, FromRequestDeploymentMixin):

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -199,13 +199,13 @@ class AzureChatCompletionRequest(ExtraForbidModel):
 
 class ChatCompletionRequestCustomFields(ExtraForbidModel):
     configuration: Optional[Dict[str, Any]] = None
+    application_properties: Optional[Dict[str, Any]] = None
 
 
 class ChatCompletionRequest(AzureChatCompletionRequest):
     addons: Optional[List[Addon]] = None
     max_prompt_tokens: Optional[PositiveInt] = None
     custom_fields: Optional[ChatCompletionRequestCustomFields] = None
-    custom_application_properties: Optional[Dict[str, Any]] = None
 
 
 class Request(ChatCompletionRequest, FromRequestDeploymentMixin):


### PR DESCRIPTION
The "custom_application_properties" field was added to the request to transfer server-side properties of the schema reach applications.