### PR TITLE
feat: added `required` enum case for `request.tool_choice`

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -182,7 +182,9 @@ class AzureChatCompletionRequest(ExtraForbidModel):
         None
     )
     tools: Optional[List[Union[Tool, StaticTool]]] = None
-    tool_choice: Optional[Union[Literal["auto", "none"], ToolChoice]] = None
+    tool_choice: Optional[
+        Union[Literal["auto", "none", "required"], ToolChoice]
+    ] = None
     stream: bool = False
     temperature: Optional[Temperature] = None
     top_p: Optional[TopP] = None


### PR DESCRIPTION
As per [API](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-01-01-preview/inference.yaml#L4508) 