### PR TITLE
feat: added json schema option for `response_format`

### DIFF
--- a/aidial_sdk/chat_completion/__init__.py
+++ b/aidial_sdk/chat_completion/__init__.py
@@ -14,6 +14,10 @@ from aidial_sdk.chat_completion.request import (
     MessageContentTextPart,
     Request,
     ResponseFormat,
+    ResponseFormatJsonObject,
+    ResponseFormatJsonSchema,
+    ResponseFormatJsonSchemaObject,
+    ResponseFormatText,
     Role,
 )
 from aidial_sdk.chat_completion.request import Stage as RequestStage

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -195,9 +195,11 @@ class ResponseFormatJsonSchema(ExtraForbidModel):
     json_schema: ResponseFormatJsonSchemaObject
 
 
-ResponseFormat = (
-    ResponseFormatText | ResponseFormatJsonObject | ResponseFormatJsonSchema
-)
+ResponseFormat = Union[
+    ResponseFormatText,
+    ResponseFormatJsonObject,
+    ResponseFormatJsonSchema,
+]
 
 
 class AzureChatCompletionRequest(ExtraForbidModel):

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -10,6 +10,7 @@ from aidial_sdk.pydantic_v1 import (
     ConstrainedFloat,
     ConstrainedInt,
     ConstrainedList,
+    Field,
     PositiveInt,
     StrictBool,
     StrictInt,
@@ -170,8 +171,33 @@ class ToolChoice(ExtraForbidModel):
     function: FunctionChoice
 
 
-class ResponseFormat(ExtraForbidModel):
-    type: Literal["text", "json_object"]
+class ResponseFormatText(ExtraForbidModel):
+    type: Literal["text"]
+
+
+class ResponseFormatJsonObject(ExtraForbidModel):
+    type: Literal["json_object"]
+
+
+class ResponseFormatJsonSchemaObject(ExtraForbidModel):
+    description: Optional[StrictStr] = None
+    name: StrictStr
+    schema_: Dict[str, Any] = Field(..., alias="schema")
+    strict: Optional[StrictBool] = False
+
+    def dict(self, *args, **kwargs):
+        kwargs["by_alias"] = True
+        return super().dict(*args, **kwargs)
+
+
+class ResponseFormatJsonSchema(ExtraForbidModel):
+    type: Literal["json_schema"]
+    json_schema: ResponseFormatJsonSchemaObject
+
+
+ResponseFormat = (
+    ResponseFormatText | ResponseFormatJsonObject | ResponseFormatJsonSchema
+)
 
 
 class AzureChatCompletionRequest(ExtraForbidModel):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,7 @@
 import json
 
-from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.chat_completion import Message, ResponseFormatJsonSchema, Role
+from aidial_sdk.chat_completion.request import ResponseFormatJsonSchemaObject
 
 
 def test_message_ser():
@@ -15,5 +16,55 @@ def test_message_deser():
     msg_dict = {"role": "system", "content": "test"}
     actual_obj = Message.parse_raw(json.dumps(msg_dict))
     expected_obj = Message(role=Role.SYSTEM, content="test")
+
+    assert actual_obj == expected_obj
+
+
+def test_response_format_serialization():
+    format_obj = ResponseFormatJsonSchema(
+        type="json_schema",
+        json_schema=ResponseFormatJsonSchemaObject(
+            description="desc",
+            name="name",
+            schema={"key": "value"},
+        ),
+    )
+
+    actual_dict = format_obj.dict()
+
+    expected_dict = {
+        "type": "json_schema",
+        "json_schema": {
+            "description": "desc",
+            "name": "name",
+            "schema": {"key": "value"},
+            "strict": False,
+        },
+    }
+
+    assert actual_dict == expected_dict
+
+
+def test_response_format_deserialization():
+    format_dict = {
+        "type": "json_schema",
+        "json_schema": {
+            "description": "desc",
+            "name": "name",
+            "schema": {"key": "value"},
+        },
+    }
+
+    actual_obj = ResponseFormatJsonSchema.parse_obj(format_dict)
+
+    expected_obj = ResponseFormatJsonSchema(
+        type="json_schema",
+        json_schema=ResponseFormatJsonSchemaObject(
+            description="desc",
+            name="name",
+            schema={"key": "value"},
+            strict=False,
+        ),
+    )
 
     assert actual_obj == expected_obj


### PR DESCRIPTION
As per [API](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-01-01-preview/inference.yaml#L4734-L4763)

See also OpenAI lib [class definition](https://github.com/openai/openai-python/blob/7193688e364bd726594fe369032e813ced1bdfe2/src/openai/types/shared/response_format_json_schema.py)