### PR TITLE
feat: sync data types with api-version 2024-10-21

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -79,7 +79,16 @@ class MessageContentTextPart(ExtraForbidModel):
     text: StrictStr
 
 
-MessageContentPart = Union[MessageContentTextPart, MessageContentImagePart]
+class MessageContentRefusalPart(ExtraForbidModel):
+    type: Literal["refusal"]
+    refusal: StrictStr
+
+
+MessageContentPart = Union[
+    MessageContentTextPart,
+    MessageContentImagePart,
+    MessageContentRefusalPart,
+]
 
 
 class Message(ExtraForbidModel):
@@ -90,6 +99,7 @@ class Message(ExtraForbidModel):
     tool_calls: Optional[List[ToolCall]] = None
     tool_call_id: Optional[StrictStr] = None
     function_call: Optional[FunctionCall] = None
+    refusal: Optional[StrictStr] = None
 
     def text(self) -> str:
         """
@@ -202,6 +212,10 @@ ResponseFormat = Union[
 ]
 
 
+class StreamOptions(ExtraForbidModel):
+    include_usage: Optional[StrictBool] = None
+
+
 class AzureChatCompletionRequest(ExtraForbidModel):
     model: Optional[StrictStr] = None
     messages: List[Message]
@@ -214,11 +228,13 @@ class AzureChatCompletionRequest(ExtraForbidModel):
         Union[Literal["auto", "none", "required"], ToolChoice]
     ] = None
     stream: bool = False
+    stream_options: Optional[StreamOptions] = None
     temperature: Optional[Temperature] = None
     top_p: Optional[TopP] = None
     n: Optional[N] = None
     stop: Optional[Union[StrictStr, Stop]] = None
     max_tokens: Optional[PositiveInt] = None
+    max_completion_tokens: Optional[PositiveInt] = None
     presence_penalty: Optional[Penalty] = None
     frequency_penalty: Optional[Penalty] = None
     logit_bias: Optional[Mapping[int, float]] = None
@@ -227,6 +243,7 @@ class AzureChatCompletionRequest(ExtraForbidModel):
     logprobs: Optional[StrictBool] = None
     top_logprobs: Optional[StrictInt] = None
     response_format: Optional[ResponseFormat] = None
+    parallel_tool_calls: Optional[StrictBool] = None
 
 
 class ChatCompletionRequestCustomFields(ExtraForbidModel):

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -228,7 +228,6 @@ class AzureChatCompletionRequest(ExtraForbidModel):
         Union[Literal["auto", "none", "required"], ToolChoice]
     ] = None
     stream: bool = False
-    stream_options: Optional[StreamOptions] = None
     temperature: Optional[Temperature] = None
     top_p: Optional[TopP] = None
     n: Optional[N] = None


### PR DESCRIPTION
As per [API spec](https://redoc-viewer.vercel.app/?url=https://raw.githubusercontent.com/Azure/azure-rest-api-specs/refs/heads/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-10-21/inference.yaml)

Note that `stream_options.include_usage` parameter wasn't added since DIAL requires all the models and applications to return usage during streaming if it makes sense.

Consequently, it's unclear what DIAL application developer should do for a request with `stream_options.include_usage=False & stream=True`. On one hand, it shouldn't return usage; on another - DIAL requires it to do it since otherwise token rate limits simply won't work.