### PR TITLE
feat: add chat completion message with developer role

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -58,6 +58,7 @@ class ToolCall(ExtraForbidModel):
 
 class Role(str, Enum):
     SYSTEM = "system"
+    DEVELOPER = "developer"
     USER = "user"
     ASSISTANT = "assistant"
     FUNCTION = "function"


### PR DESCRIPTION
As per API [spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-02-01-preview/inference.yaml#L2835-L2871)

<details><summary>developer message</summary>

```yaml
    ChatCompletionRequestDeveloperMessage:
      type: object
      title: Developer message
      description: >
        Developer-provided instructions that the model should follow, regardless
        of

        messages sent by the user. With o1 models and newer, `developer`
        messages

        replace the previous `system` messages.
      properties:
        content:
          description: The contents of the developer message.
          oneOf:
            - type: string
              description: The contents of the developer message.
              title: Text content
            - type: array
              description: An array of content parts with a defined type. For developer
                messages, only type `text` is supported.
              title: Array of content parts
              items:
                $ref: "#/components/schemas/chatCompletionRequestDeveloperMessageContentPart"
              minItems: 1
        role:
          type: string
          enum:
            - developer
          description: The role of the messages author, in this case `developer`.
        name:
          type: string
          description: An optional name for the participant. Provides the model
            information to differentiate between participants of the same role.
      required:
        - content
        - role
```

</details>