### PR TITLE
chore: add Python 3.13 to the CI test suite

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,4 @@ jobs:
     secrets: inherit
     with:
       python_version: 3.8
-      test_python_versions: '["3.8", "3.9", "3.10", "3.11", "3.12"]'
+      test_python_versions: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,4 +10,4 @@ jobs:
     secrets: inherit
     with:
       python_version: 3.8
-      test_python_versions: '["3.8", "3.9", "3.10", "3.11", "3.12"]'
+      test_python_versions: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'


### PR DESCRIPTION
Follow up of https://github.com/epam/ai-dial-sdk/pull/230