### PR TITLE
chore(auth): use FastAPI's HTTPBearer for JWT token extraction

### DIFF
--- a/aidial_sdk/deployment/from_request_mixin.py
+++ b/aidial_sdk/deployment/from_request_mixin.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Mapping, Optional, Type, TypeVar
 from urllib.parse import urljoin
 
 import fastapi
+from fastapi.security import HTTPBearer
 
 from aidial_sdk.exceptions import InternalServerError, InvalidRequestError
 from aidial_sdk.pydantic_v1 import Field, SecretStr, StrictStr, root_validator
@@ -34,6 +35,7 @@ class FromRequestDeploymentMixin(FromRequestMixin):
 
     _DIAL_APPLICATION_PROPERTIES_HEADER = "X-DIAL-APPLICATION-PROPERTIES"
     _DIAL_APPLICATION_ID_HEADER = "X-DIAL-APPLICATION-ID"
+    _bearer = HTTPBearer(auto_error=False)
 
     headers: Mapping[str, str]
     base_url: Optional[str] = None
@@ -139,7 +141,8 @@ class FromRequestDeploymentMixin(FromRequestMixin):
             raise InvalidRequestError("Api-Key header is required")
         del headers["Api-Key"]
 
-        jwt = headers.get("Authorization")
+        auth_credentials = await cls._bearer(request)
+        jwt = auth_credentials.credentials if auth_credentials else None
         del headers["Authorization"]
 
         application_properties = None


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #196

### Description of changes

<!-- Please explain the changes you made right below this line. -->

This pull request improves authentication handling in the `FromRequestDeploymentMixin` class by integrating FastAPI's `HTTPBearer` authentication scheme. Key updates include:

- `aidial_sdk/deployment/from_request_mixin.py`: Imported `HTTPBearer` from FastAPI to support bearer token authentication.
- `aidial_sdk/deployment/from_request_mixin.py`: Introduced a `_bearer` class attribute initialized with `HTTPBearer(auto_error=False)` to enable optional error raising on missing/invalid tokens.
- `aidial_sdk/deployment/from_request_mixin.py`: Refactored the `from_request` method to use `_bearer` for token extraction. The method now processes the `Authorization` header using `_bearer` and extracts the token from the resulting credentials.

These changes address an issue where the JWT token was not correctly retrieved from the `Authorization: Bearer` header.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
