### PR TITLE
fix: drop support of Python 3.8

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,5 +9,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/python_package_pr.yml@2.1.0
     secrets: inherit
     with:
-      python-version: 3.8
-      code-checks-python-versions: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
+      python-version: 3.9
+      code-checks-python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/python_package_release.yml@2.1.0
     secrets: inherit
     with:
-      python-version: 3.8
-      code-checks-python-versions: '["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]'
+      python-version: 3.9
+      code-checks-python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You will see the JSON response as:
 
 ## Developer environment
 
-This project uses [Python>=3.8](https://www.python.org/downloads/) and [Poetry>=1.6.1](https://python-poetry.org/) as a dependency manager.
+This project uses [Python>=3.9](https://www.python.org/downloads/) and [Poetry>=1.6.1](https://python-poetry.org/) as a dependency manager.
 
 Check out Poetry's [documentation on how to install it](https://python-poetry.org/docs/#installation) on your system before proceeding.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def format(session: nox.Session):
     format_with_args(session, SRC)
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
 # Testing against earliest and latest supported versions of the dependencies
 @nox.parametrize("pydantic", ["1.10.17", "2.8.2"])
 @nox.parametrize("httpx", ["0.25.0", "0.27.0"])

--- a/poetry.lock
+++ b/poetry.lock
@@ -162,9 +162,6 @@ files = [
     {file = "annotated_types-0.5.0.tar.gz", hash = "sha256:47cdc3490d9ac1506ce92c7aaa76c579dc3509ff11e098fc867e5130ab7be802"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
-
 [[package]]
 name = "anyio"
 version = "3.7.1"
@@ -2335,5 +2332,5 @@ telemetry = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-grpc", "ope
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.1,<4.0"
-content-hash = "c3834229001f110e658690be91871ba5f6cc1bb4b49d547dea9ff158e78f52b5"
+python-versions = ">=3.9,<4.0"
+content-hash = "91827be2545febff31dcd5f7eaf6b22f4bdd75ada715861e3c107fa1146f8e0b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/epam/ai-dial-sdk"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 fastapi = ">=0.51,<1.0"
 uvicorn = ">=0.19,<1.0"
 pydantic = ">=1.10.17,<3"


### PR DESCRIPTION
Since 3.8 has reached [end-of-life](https://devguide.python.org/versions/#status-of-python-versions) a long time ago.