### PR TITLE
chore: set explicit permissions for CI jobs

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,5 +1,8 @@
 name: "Validate PR title"
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: PR Workflow
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [development, release-*]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release Workflow
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [development, release-*]


### PR DESCRIPTION
Potential fix for [https://github.com/epam/ai-dial-sdk/security/code-scanning/25](https://github.com/epam/ai-dial-sdk/security/code-scanning/25)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the provided details, most basic CI workflows only require `contents: read`. If additional permissions are needed, they can be added later after analyzing the specific requirements of the reusable workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
