### PR TITLE
fix: allow merging of non-indexed lists in chat completion chunks

### DIFF
--- a/aidial_sdk/utils/merge_chunks.py
+++ b/aidial_sdk/utils/merge_chunks.py
@@ -16,10 +16,6 @@ INCONSISTENT_INDEXED_LIST_ERROR_MESSAGE = (
     "All elements of a list must be either indexed or not indexed"
 )
 
-CANNOT_MERGE_NON_INDEXED_LISTS_ERROR_MESSAGE = (
-    "Cannot merge two non-indexed non-empty lists"
-)
-
 CANNOT_MERGE_NON_INDEXED_AND_INDEXED_LISTS_ERROR_MESSAGE = (
     "Cannot merge a non-indexed list with an indexed list"
 )
@@ -112,7 +108,8 @@ def merge_lists(target: list, source: list, path: Path) -> list:
             return copy.deepcopy(source)
 
     if not is_target_indexed and not is_source_indexed:
-        raise AssertionError(CANNOT_MERGE_NON_INDEXED_LISTS_ERROR_MESSAGE)
+        target.extend(copy.deepcopy(source))
+        return target
 
     assert (
         is_target_indexed and is_source_indexed

--- a/tests/test_merge_chunks.py
+++ b/tests/test_merge_chunks.py
@@ -10,7 +10,6 @@ import pytest
 
 from aidial_sdk.utils.merge_chunks import (
     CANNOT_MERGE_NON_INDEXED_AND_INDEXED_LISTS_ERROR_MESSAGE,
-    CANNOT_MERGE_NON_INDEXED_LISTS_ERROR_MESSAGE,
     INCONSISTENT_INDEXED_LIST_ERROR_MESSAGE,
     cleanup_indices,
     merge,
@@ -187,12 +186,14 @@ merge_chunks_cases: List[Test] = [
     ),
     Test(
         chunks=[{"a": [1]}, {"a": [2]}],
-        expected=AssertionError(CANNOT_MERGE_NON_INDEXED_LISTS_ERROR_MESSAGE),
+        expected={"a": [1, 2]},
+        fixed_order=True,
         desc="Merge lists of non-dicts",
     ),
     Test(
-        chunks=[{"a": [{"b": 1}]}, {"a": [{"b": 2}]}],
-        expected=AssertionError(CANNOT_MERGE_NON_INDEXED_LISTS_ERROR_MESSAGE),
+        chunks=[{"a": [{"b": 1}]}, {"a": [{"c": 2}]}],
+        expected={"a": [{"b": 1}, {"c": 2}]},
+        fixed_order=True,
         desc="Merge lists of non-indexed dicts",
     ),
     Test(


### PR DESCRIPTION
Required to support logprobs that are reported as non-indexed lists:

<details><summary>Request</summary>

```json
{
  "stream": true,
  "logprobs": true,
  "messages": [
    {
      "role": "user",
      "content": "Reply with ONLY two words: Hello world"
    }
  ]
}
```
</details>

<details><summary>Response</summary>

```
data: {"id": "chatcmpl-id123", "object": "chat.completion.chunk", "created": 1749480000, "model": "gpt-4o", "system_fingerprint": "fp", "choices": [{"index": 0, "delta": {"role": "assistant", "content": "", "refusal": null}, "logprobs": {"content": [], "refusal": null}, "finish_reason": null}]}

data: {"id": "chatcmpl-id123", "object": "chat.completion.chunk", "created": 1749480000, "model": "gpt-4o", "system_fingerprint": "fp", "choices": [{"index": 0, "delta": {"content": "Hello"}, "logprobs": {"content": [{"token": "Hello", "logprob": -0.0030339211, "bytes": [72, 101, 108, 108, 111], "top_logprobs": []}], "refusal": null}, "finish_reason": null}]}

data: {"id": "chatcmpl-id123", "object": "chat.completion.chunk", "created": 1749480000, "model": "gpt-4o", "system_fingerprint": "fp", "choices": [{"index": 0, "delta": {"content": " world"}, "logprobs": {"content": [{"token": " world", "logprob": -0.0089504095, "bytes": [32, 119, 111, 114, 108, 100], "top_logprobs": []}], "refusal": null}, "finish_reason": null}]}

data: {"id": "chatcmpl-id123", "object": "chat.completion.chunk", "created": 1749480000, "model": "gpt-4o", "system_fingerprint": "fp", "choices": [{"index": 0, "delta": {}, "logprobs": null, "finish_reason": "stop"}]}

data: [DONE]
```
</details>