### PR TITLE
feat: add strict field to function declaration

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -137,6 +137,7 @@ class Addon(ExtraAllowModel):
 
 class Function(ExtraAllowModel):
     name: StrictStr
+    strict: bool = False
     description: Optional[StrictStr] = None
     parameters: Optional[Dict] = None
 


### PR DESCRIPTION
As per [API spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2025-04-01-preview/inference.yaml#L5061-L5065):

```yaml
        strict:
          type: boolean
          nullable: true
          default: false
          description: Whether to enable strict schema adherence when generating the function call. If set to true, the model will follow the exact schema defined in the `parameters` field. Only a subset of JSON Schema is supported when `strict` is `true`. Learn more about Structured Outputs in the [function calling guide](docs/guides/function-calling).

```