### PR TITLE
feat: support extra error fields in DIAL exceptions

### DIFF
--- a/aidial_sdk/exceptions.py
+++ b/aidial_sdk/exceptions.py
@@ -19,7 +19,7 @@ class HTTPException(Exception):
         code: Optional[str] = None,
         display_message: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
-        extra_error_fields: Optional[dict] = None,
+        **kwargs,
     ) -> None:
         super().__init__(message)
         status_code = int(status_code)
@@ -31,24 +31,22 @@ class HTTPException(Exception):
         self.code = code or str(status_code)
         self.display_message = display_message
         self.headers = headers
-        self.extra_error = extra_error_fields or {}
+        self.extra_fields = kwargs
 
     def __repr__(self):
         # headers field is omitted deliberately
         # since it may contain sensitive information
-        return (
-            "%s(message=%r, status_code=%r, type=%r, param=%r, code=%r, display_message=%r, extra_error=%r)"
-            % (
-                self.__class__.__name__,
-                self.message,
-                self.status_code,
-                self.type,
-                self.param,
-                self.code,
-                self.display_message,
-                self.extra_error,
-            )
-        )
+        error = {
+            "message": self.message,
+            "status_code": self.status_code,
+            "type": self.type,
+            "param": self.param,
+            "code": self.code,
+            "display_message": self.display_message,
+            **self.extra_fields,
+        }
+        args = ", ".join([f"{k}={v!r}" for k, v in error.items()])
+        return f"{self.__class__.__name__}({args})"
 
     def json_error(self) -> dict:
         return {
@@ -59,7 +57,7 @@ class HTTPException(Exception):
                     "param": self.param,
                     "code": self.code,
                     "display_message": self.display_message,
-                    **self.extra_error,
+                    **self.extra_fields,
                 }
             )
         }

--- a/aidial_sdk/exceptions.py
+++ b/aidial_sdk/exceptions.py
@@ -19,6 +19,7 @@ class HTTPException(Exception):
         code: Optional[str] = None,
         display_message: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        extra_error_fields: Optional[dict] = None,
     ) -> None:
         super().__init__(message)
         status_code = int(status_code)
@@ -30,12 +31,13 @@ class HTTPException(Exception):
         self.code = code or str(status_code)
         self.display_message = display_message
         self.headers = headers
+        self.extra_error = extra_error_fields or {}
 
     def __repr__(self):
         # headers field is omitted deliberately
         # since it may contain sensitive information
         return (
-            "%s(message=%r, status_code=%r, type=%r, param=%r, code=%r, display_message=%r)"
+            "%s(message=%r, status_code=%r, type=%r, param=%r, code=%r, display_message=%r, extra_error=%r)"
             % (
                 self.__class__.__name__,
                 self.message,
@@ -44,6 +46,7 @@ class HTTPException(Exception):
                 self.param,
                 self.code,
                 self.display_message,
+                self.extra_error,
             )
         )
 
@@ -56,6 +59,7 @@ class HTTPException(Exception):
                     "param": self.param,
                     "code": self.code,
                     "display_message": self.display_message,
+                    **self.extra_error,
                 }
             )
         }

--- a/tests/applications/broken.py
+++ b/tests/applications/broken.py
@@ -15,6 +15,12 @@ def _raise_exception(exception_type: str):
         return 1 / 0
     elif exception_type == "sdk_exception_with_display_message":
         raise DIALException("Test error", 503, display_message="I'm broken")
+    elif exception_type == "sdk_exception_with_extra_fields":
+        raise DIALException(
+            "Test error",
+            503,
+            extra_error_fields={"status": 503, "details": "error details"},
+        )
     elif exception_type == "sdk_exception_with_headers":
         raise DIALException(
             "Too many requests", 429, headers={"Retry-After": "42"}

--- a/tests/applications/broken.py
+++ b/tests/applications/broken.py
@@ -19,7 +19,8 @@ def _raise_exception(exception_type: str):
         raise DIALException(
             "Test error",
             503,
-            extra_error_fields={"status": 503, "details": "error details"},
+            status=503,
+            details="error details",
         )
     elif exception_type == "sdk_exception_with_headers":
         raise DIALException(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 import pytest
 
+from aidial_sdk.exceptions import HTTPException
 from tests.applications.broken import (
     ImmediatelyBrokenApplication,
     RuntimeBrokenApplication,
@@ -186,3 +187,20 @@ def test_no_api_key():
 
     assert response.status_code == 400
     assert response.json() == API_KEY_IS_MISSING
+
+
+def test_error_repr():
+    assert (
+        repr(
+            HTTPException(
+                message="a",
+                status_code=404,
+                type="c",
+                param="d",
+                code="e",
+                display_message="f",
+                g="h",
+            )
+        )
+        == "HTTPException(message='a', status_code=404, type='c', param='d', code='e', display_message='f', g='h')"
+    )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -64,6 +64,19 @@ error_testcases: List[ErrorTestCase] = [
         },
     ),
     ErrorTestCase(
+        "sdk_exception_with_extra_fields",
+        503,
+        {
+            "error": {
+                "message": "Test error",
+                "type": "runtime_error",
+                "details": "error details",
+                "status": 503,
+                "code": "503",
+            }
+        },
+    ),
+    ErrorTestCase(
         None,
         400,
         {


### PR DESCRIPTION
Models may return useful diagnostic information in non-standard fields of the `error` dictionary, such as `details` or `innerError`. To faithfully represent these errors as DIAL exceptions, we need to enable extra fields in the DIAL exceptions.

The PR unblocks https://github.com/epam/ai-dial-adapter-openai/issues/284