### PR TITLE
chore: bump langchain from 0.3.7 to 0.3.26; bump langchain-text-splitters from 0.3.0 to 0.3.9

### DIFF
--- a/examples/langchain_rag/requirements.txt
+++ b/examples/langchain_rag/requirements.txt
@@ -1,5 +1,5 @@
 aidial-sdk>=0.10
-langchain==0.3.7
+langchain==0.3.26
 langchain-community==0.3.27
 langchain-openai==0.2.6
 langchain-text-splitters==0.3.9

--- a/examples/langchain_rag/requirements.txt
+++ b/examples/langchain_rag/requirements.txt
@@ -2,7 +2,7 @@ aidial-sdk>=0.10
 langchain==0.3.7
 langchain-community==0.3.27
 langchain-openai==0.2.6
-langchain-text-splitters==0.3.0
+langchain-text-splitters==0.3.9
 tiktoken==0.7.0
 openai==1.54.0
 httpx==0.27.2


### PR DESCRIPTION
Fixing security issue: https://github.com/epam/ai-dial-sdk/security/dependabot/76