### PR TITLE
feat: add reasoning_effort parameter

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -244,6 +244,14 @@ ResponseFormat = Union[
 ]
 
 
+class ReasoningEffort(str, Enum):
+    NONE = "none"
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
 class AzureChatCompletionRequest(ExtraAllowModel):
     model: Optional[StrictStr] = None
     messages: List[Message]
@@ -270,6 +278,7 @@ class AzureChatCompletionRequest(ExtraAllowModel):
     seed: Optional[StrictInt] = None
     logprobs: Optional[StrictBool] = None
     top_logprobs: Optional[StrictInt] = None
+    reasoning_effort: Optional[ReasoningEffort] = None
     response_format: Optional[ResponseFormat] = None
     parallel_tool_calls: Optional[StrictBool] = None
 


### PR DESCRIPTION
[Azure OpenAI REST spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/ai/data-plane/OpenAI.v1/azure-v1-preview-generated.yaml) doesn't have `none` and `minimum` enum values for the `reasoning_effort` field.

However, OpenAI Platform [documents](https://platform.openai.com/docs/api-reference/chat/create#chat_create-reasoning_effort) these enums as well as [openai](https://github.com/openai/openai-python/blob/41ee03ffe985a7362f0275c7f500080cb1d58cdd/src/openai/types/shared/reasoning_effort.py#L8) SDK, so we follow them in the DIAL SDK.