### PR TITLE
chore: relax upper bound on prometheus-client dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2454,4 +2454,4 @@ telemetry = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-grpc", "ope
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "870d1e1ad556a9a17196484d6085cbee8cd7d2a01149c5a29f89411ffe77b934"
+content-hash = "4a2c693c13bc5298abceee6af0223ba2c2b27b141d219a2413ed02fc20b0229a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ telemetry = [
     "opentelemetry-instrumentation-system-metrics (>=0.43b0)",
     "opentelemetry-instrumentation-urllib (>=0.43b0)",
     "opentelemetry-exporter-prometheus (>=0.43b0)",
-    "prometheus-client (>=0.17.1,<=0.21)",
+    "prometheus-client (>=0.17.1,<1.0)",
 ]
-httpx = ["httpx (>=0.25.0,<1)"]
+httpx = ["httpx (>=0.25.0,<1.0)"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.2"


### PR DESCRIPTION
A client tries to use both `fastmcp==2.14.0` and the `aidial-sdk==0.30.0`. It's impossible since there is a strict upper bound limit on the `prometheus-client` package (`<=0.21`):

```txt
    Because no versions of pydocket match >0.15.2,<0.15.3 || >0.15.3,<0.15.4 || >0.15.4,<0.15.5
and pydocket (0.15.2) depends on prometheus-client (>=0.21.1), pydocket (>=0.15.2,<0.15.3 || >0.15.3,<0.15.4 || >0.15.4,<0.15.5) requires prometheus-client (>=0.21.1).
    And because pydocket (0.15.3) depends on prometheus-client (>=0.21.1)
and pydocket (0.15.4) depends on prometheus-client (>=0.21.1), pydocket (>=0.15.2,<0.15.5) requires prometheus-client (>=0.21.1).
    Because no versions of fastmcp match >2.14.0,<2.14.1 || >2.14.1,<2.14.2 || >2.14.2,<3.0.0
and fastmcp (2.14.0) depends on pydocket (>=0.15.2), fastmcp (>=2.14.0,<2.14.1 || >2.14.1,<2.14.2 || >2.14.2,<3.0.0) requires pydocket (>=0.15.2).
    Thus, fastmcp (>=2.14.0,<2.14.1 || >2.14.1,<2.14.2 || >2.14.2,<3.0.0) requires prometheus-client (>=0.21.1) or pydocket (>=0.15.5).
(1) So, because fastmcp (2.14.1) depends on pydocket (>=0.15.5), fastmcp (>=2.14.0,<2.14.2 || >2.14.2,<3.0.0) requires prometheus-client (>=0.21.1) or pydocket (>=0.15.5).

    Because no versions of pydocket match >0.15.5,<0.15.6 || >0.15.6,<0.16.0 || >0.16.0,<0.16.1 || >0.16.1,<0.16.2 || >0.16.2,<0.16.3
and pydocket (0.15.5) depends on prometheus-client (>=0.21.1), pydocket (>=0.15.5,<0.15.6 || >0.15.6,<0.16.0 || >0.16.0,<0.16.1 || >0.16.1,<0.16.2 || >0.16.2,<0.16.3) requires prometheus-client (>=0.21.1).
    And because pydocket (0.15.6) depends on prometheus-client (>=0.21.1)
and pydocket (0.16.0) depends on prometheus-client (>=0.21.1), pydocket (>=0.15.5,<0.16.1 || >0.16.1,<0.16.2 || >0.16.2,<0.16.3) requires prometheus-client (>=0.21.1).
    And because pydocket (0.16.1) depends on prometheus-client (>=0.21.1)
and pydocket (0.16.2) depends on prometheus-client (>=0.21.1), pydocket (>=0.15.5,<0.16.3) requires prometheus-client (>=0.21.1).
    And because fastmcp (>=2.14.0,<2.14.2 || >2.14.2,<3.0.0) requires prometheus-client (>=0.21.1) or pydocket (>=0.15.5) (1), fastmcp (>=2.14.0,<2.14.2 || >2.14.2,<3.0.0) requires prometheus-client (>=0.21.1) or pydocket (>=0.16.3)
    And because fastmcp (2.14.2) depends on pydocket (>=0.16.3), fastmcp (>=2.14.0,<3.0.0) requires prometheus-client (>=0.21.1) or pydocket (>=0.16.3).
    Because pydocket (0.16.3) depends on prometheus-client (>=0.21.1)
and no versions of pydocket match >0.16.3, pydocket (>=0.16.3) requires prometheus-client (>=0.21.1).
    Thus, fastmcp (>=2.14.0,<3.0.0) requires prometheus-client (>=0.21.1).
    Because no versions of aidial-sdk match >0.30.0,<0.31.0
and aidial-sdk[telemetry] (0.30.0) depends on prometheus-client (>=0.17.1,<=0.21), aidial-sdk[telemetry] (>=0.30.0,<0.31.0) requires prometheus-client (>=0.17.1,<=0.21).
    Thus, aidial-sdk[telemetry] (>=0.30.0,<0.31.0) is incompatible with fastmcp (>=2.14.0,<3.0.0).
    So, because client-app depends on both aidial-sdk[telemetry] (^0.30.0) and fastmcp (>=2.14.0,<3.0.0), version solving failed.
```

The fix relaxes this restriction.