### PR TITLE
fix!: drop support of Python 3.9

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,5 +9,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/python_package_pr.yml@2.8.1
     secrets: inherit
     with:
-      python-version: 3.9
-      code-checks-python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+      python-version: 3.10
+      code-checks-python-versions: '["3.10", "3.11", "3.12", "3.13"]'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,5 +9,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/python_package_pr.yml@2.8.1
     secrets: inherit
     with:
-      python-version: 3.10
+      python-version: "3.10"
       code-checks-python-versions: '["3.10", "3.11", "3.12", "3.13"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/python_package_release.yml@2.8.1
     secrets: inherit
     with:
-      python-version: 3.9
-      code-checks-python-versions: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+      python-version: 3.10
+      code-checks-python-versions: '["3.10", "3.11", "3.12", "3.13"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/python_package_release.yml@2.8.1
     secrets: inherit
     with:
-      python-version: 3.10
+      python-version: "3.10"
       code-checks-python-versions: '["3.10", "3.11", "3.12", "3.13"]'

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@
 - [Overview](#overview)
 - [Environment Variables](#environment-variables)
 - [Usage](#usage)
-    - [Echo application example](#echo-application-example)
-      - [Run](#Run)
-      - [Check](#Check)
+  - [Echo application example](#echo-application-example)
+    - [Run](#run)
+    - [Check](#check)
 - [Developer environment](#developer-environment)
-    - [IDE configuration](#IDE-configuration)
-- [Set up](#Set-up)
-  - [Lint](#Lint)
-  - [Test](#Test)
-  - [Clean](#Clean)
-  - [Build](#Build)
-  - [Publish](#Publish)
+  - [IDE configuration](#ide-configuration)
+- [Set up](#set-up)
+  - [Lint](#lint)
+  - [Test](#test)
+  - [Clean](#clean)
+  - [Build](#build)
+  - [Publish](#publish)
 
 ---
 
@@ -136,7 +136,7 @@ You will see the JSON response as:
 ## Developer environment
 
 > [!IMPORTANT]
-> This project uses [Python>=3.9](https://www.python.org/downloads/) and [Poetry>=2.1.1](https://python-poetry.org/) as a dependency manager.
+> This project uses [Python>=3.10](https://www.python.org/downloads/) and [Poetry>=2.1.1](https://python-poetry.org/) as a dependency manager.
 >
 > Check out Poetry's [documentation on how to install it](https://python-poetry.org/docs/#installation) on your system before proceeding.
 
@@ -152,11 +152,11 @@ This will install all requirements for running the package, linting, formatting 
 
 The recommended IDE is [VSCode](https://code.visualstudio.com/).
 Open the project in VSCode and install the recommended extensions.
- 
+
 The VSCode is configured to use PEP-8 compatible formatter [Black](https://black.readthedocs.io/en/stable/index.html).
 
 Alternatively you can use [PyCharm](https://www.jetbrains.com/pycharm/).
- 
+
 Set-up the Black formatter for PyCharm [manually](https://black.readthedocs.io/en/stable/integrations/editors.html#pycharm-intellij-idea) or
 install PyCharm>=2023.2 with [built-in Black support](https://blog.jetbrains.com/pycharm/2023/07/2023-2/#black).
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ class UsePydanticV2(Enum):
     NO = "0"
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.10", "3.11", "3.12", "3.13"])
 # Testing against earliest and latest supported versions of the dependencies
 @nox.parametrize(
     "pydantic",

--- a/poetry.lock
+++ b/poetry.lock
@@ -2487,5 +2487,5 @@ telemetry = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-grpc", "ope
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<4.0"
-content-hash = "2f29fd4e69bf6dc570bacd58d89b5f3957b8cc22439135d62e62be068dc98bf1"
+python-versions = ">=3.10,<4.0"
+content-hash = "b94ac7c33243dd05b84bfbcd79b2de2da2c2686241e09eafecd6e80bf6465286"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Framework to create applications and model adapters for AI DIAL"
 authors = [{ name = "EPAM RAIL", email = "SpecialEPM-DIALDevTeam@epam.com" }]
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "fastapi (>=0.51,<1.0)",
     "uvicorn (>=0.19,<1.0)",

--- a/tests/test_header_propagation.py
+++ b/tests/test_header_propagation.py
@@ -16,14 +16,13 @@ from requests.structures import CaseInsensitiveDict
 from aidial_sdk.header_propagator import HeaderPropagator
 from aidial_sdk.utils.json import remove_nones
 from tests.header_propagation.client import app as sender
-from tests.utils.text import removeprefix
 
 DIAL_URL = "http://dial.example.com"
 NON_DIAL_URL = "http://non-dial.example.com"
 API_KEY = "test-api-key"
 
 URL_PATTERN = re.compile(rf"{re.escape(DIAL_URL)}|{re.escape(NON_DIAL_URL)}")
-HOSTS = [removeprefix(url, "http://") for url in [DIAL_URL, NON_DIAL_URL]]
+HOSTS = [url.removeprefix("http://") for url in [DIAL_URL, NON_DIAL_URL]]
 
 
 @pytest.fixture

--- a/tests/utils/text.py
+++ b/tests/utils/text.py
@@ -1,5 +1,0 @@
-# str.removeprefix method was introduced in Python 3.9
-def removeprefix(text: str, prefix: str) -> str:
-    if text.startswith(prefix):
-        return text[len(prefix) :]
-    return text


### PR DESCRIPTION
1. Python 3.9 reached [end-of-life](https://devguide.python.org/versions/) on October 31, 2025.
2. The dependency on Python 3.9 blocks the security fix for the [filelock](https://github.com/epam/ai-dial-sdk/security/dependabot/83) package which doesn't support Python 3.9. The only user of `filelock` is `nox`:

```
❯ poetry show filelock --tree --why
virtualenv 20.26.6
└── filelock >=3.12.2,<4
❯ poetry show virtualenv --tree --why
nox 2023.4.22
└── virtualenv >=14
    ├── distlib >=0.3.7,<1
    ├── filelock >=3.12.2,<4
    └── platformdirs >=3.9.1,<5
❯ poetry show nox --tree --why
Package nox is a direct dependency.
```