### PR TITLE
fix: fix parsing of embedding request by Pydantic V2

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -28,8 +28,13 @@ class Attachment(ExtraAllowModel, IgnoreIndex):
 
     @model_validator(mode="after")
     @classmethod
-    def check_data_or_url(cls, values: "Attachment"):
-        data, url = values.data, values.url
+    def check_data_or_url(cls, values: Any):
+        if isinstance(values, cls):
+            data = values.data
+            url = values.url
+        else:
+            data = values.get("data")
+            url = values.get("url")
 
         if data is None and url is None:
             raise ValueError(

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -26,10 +26,10 @@ class Attachment(ExtraAllowModel, IgnoreIndex):
     reference_type: Optional[StrictStr] = None
     reference_url: Optional[StrictStr] = None
 
-    @model_validator(mode="before")
+    @model_validator(mode="after")
     @classmethod
-    def check_data_or_url(cls, values: Any):
-        data, url = values.get("data"), values.get("url")
+    def check_data_or_url(cls, values: "Attachment"):
+        data, url = values.data, values.url
 
         if data is None and url is None:
             raise ValueError(

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -3,8 +3,10 @@ from typing import List
 import pytest
 
 from aidial_sdk import DIALApp
+from aidial_sdk.embeddings.request import EmbeddingsRequest
 from tests.applications.simple_embeddings import SimpleEmbeddings
 from tests.utils.endpoint_test import TestCase, run_endpoint_test
+from tests.utils.pydantic import model_parse
 
 deployment = "test-app"
 app = DIALApp().add_embeddings(deployment, SimpleEmbeddings())
@@ -80,5 +82,14 @@ testcases: List[TestCase] = [
 
 
 @pytest.mark.parametrize("testcase", testcases)
-def test_embeddings(testcase: TestCase):
+def test_embeddings_call(testcase: TestCase):
     run_endpoint_test(testcase)
+
+
+@pytest.mark.parametrize("testcase", testcases)
+def test_embeddings_request_parsing(testcase: TestCase):
+    request = testcase.request_body
+    request.setdefault("encoding_format", "float")
+
+    parsed = model_parse(EmbeddingsRequest, request)
+    assert parsed.model_dump(exclude_none=True) == request

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -9,24 +9,18 @@ from tests.utils.endpoint_test import TestCase, run_endpoint_test
 deployment = "test-app"
 app = DIALApp().add_embeddings(deployment, SimpleEmbeddings())
 
-expected_response_1 = {
-    "data": [
-        {"embedding": [0.0], "index": 0, "object": "embedding"},
-    ],
-    "model": "dummy",
-    "object": "list",
-    "usage": {"prompt_tokens": 1, "total_tokens": 1},
-}
 
-expected_response_2 = {
-    "data": [
-        {"embedding": [0.0], "index": 0, "object": "embedding"},
-        {"embedding": [1.0], "index": 1, "object": "embedding"},
-    ],
-    "model": "dummy",
-    "object": "list",
-    "usage": {"prompt_tokens": 2, "total_tokens": 2},
-}
+def _expected_response(n: int) -> dict:
+    return {
+        "data": [
+            {"embedding": [float(i)], "index": i, "object": "embedding"}
+            for i in range(n)
+        ],
+        "model": "dummy",
+        "object": "list",
+        "usage": {"prompt_tokens": n, "total_tokens": n},
+    }
+
 
 testcases: List[TestCase] = [
     TestCase(
@@ -40,21 +34,47 @@ testcases: List[TestCase] = [
                 "instruction": "instruction",
             },
         },
-        expected_response_1,
+        _expected_response(1),
     ),
     TestCase(
         app,
         deployment,
         "embeddings",
         {"input": [15339]},
-        expected_response_1,
+        _expected_response(1),
     ),
     TestCase(
         app,
         deployment,
         "embeddings",
         {"input": ["a", "b"]},
-        expected_response_2,
+        _expected_response(2),
+    ),
+    TestCase(
+        app,
+        deployment,
+        "embeddings",
+        {
+            "input": ["a"],
+            "custom_input": [
+                "input0",
+                ["input1"],
+                ["input2-part1", "input2-part2"],
+                {
+                    "type": "text/plain",
+                    "data": "attachment data1",
+                },
+                [
+                    "attachment title",
+                    {
+                        "type": "text/plain",
+                        "data": "attachment data2",
+                    },
+                ],
+            ],
+            "custom_fields": {"instruction": "instruction"},
+        },
+        _expected_response(1),
     ),
 ]
 


### PR DESCRIPTION
The parsing of the following embedding request:

```json
{ "input": ["input1"], "custom_input": [["input2"]] }
```

was failing with the error:

```txt
    @model_validator(mode="before")
    @classmethod
    def check_data_or_url(cls, values: Any):
>       data, url = values.get("data"), values.get("url")
E       AttributeError: 'list' object has no attribute 'get'
```

where `values` ends up being `["input2"]`.

It happens because the validator `@model_validator(mode="before")` in `Attachment` class is run **before** the appropriate instance is created out of the many `Union` alternatives:

```py
EmbeddingsMultiModalInput = Union[
    StrictStr, Attachment, List[Union[StrictStr, Attachment]]
]
```

The solution is to use `mode="after"`.