### PR TITLE
feat: avoid unnecessary OpenTelemetry imports

### DIFF
--- a/aidial_sdk/application.py
+++ b/aidial_sdk/application.py
@@ -95,8 +95,7 @@ class DIALApp(FastAPI):
         self._allow_extra_request_fields = allow_extra_request_fields
         self._dial_url = dial_url
 
-        if telemetry_config is not None:
-            self.configure_telemetry(telemetry_config)
+        self.configure_telemetry(telemetry_config)
 
         if propagate_auth_headers:
             if not dial_url:
@@ -121,16 +120,19 @@ class DIALApp(FastAPI):
 
         self.add_exception_handler(DIALException, dial_exception_handler)
 
-    def configure_telemetry(self, config: TelemetryConfig):
+    def configure_telemetry(self, config: TelemetryConfig | None):
+        if config is None or config.is_noop():
+            return
+
         try:
             from aidial_sdk.telemetry.init import init_telemetry
+
+            init_telemetry(app=self, config=config)
         except ImportError:
             raise ValueError(
                 "Missing telemetry dependencies. "
                 "Install the package with the extras: aidial-sdk[telemetry]"
             )
-
-        init_telemetry(app=self, config=config)
 
     def add_embeddings(
         self, deployment_name: str, impl: Embeddings

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -47,3 +47,8 @@ class TelemetryConfig(BaseModel):
     metrics: MetricsConfig | None = (
         MetricsConfig() if OTEL_METRICS_EXPORTER else None
     )
+
+    def is_noop(self):
+        return (
+            self.logs is None and self.tracing is None and self.metrics is None
+        )


### PR DESCRIPTION
Before the fix, the following code triggered the import of `open-telemetry-*` packages. After the fix, it doesn't.

```py
app = DIALApp(
    telemetry_config=TelemetryConfig()
)
```

The real use case is the [dynamic instrumentation](https://docs.datadoghq.com/tracing/trace_collection/dynamic_instrumentation/) of the VertexAI adapter by Datadog.

Datadog injects its own telemetry dependencies that **clash** with the ones imported by the VertexAI adapter.