### PR TITLE
feat: support propagation of arbitrary headers to DIAL Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <h1 align="center">
-         AI DIAL Python SDK
-    </h1>
+    AI DIAL Python SDK
+</h1>
+<p align="center">
     <p align="center">
-        <p align="center">
-        <a href="https://dialx.ai/">
-          <img src="https://dialx.ai/dialx_logo.svg" alt="About DIALX">
-        </a>
-    </p>
+    <a href="https://dialx.ai/">
+        <img src="https://dialx.ai/logo/dialx_logo.svg" alt="About DIALX">
+    </a>
+</p>
 <h4 align="center">
     <a href="https://pypi.org/project/aidial-sdk/">
         <img src="https://img.shields.io/pypi/v/aidial-sdk.svg" alt="PyPI version">

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ Applications and model adapters implemented using this framework will be compati
 
 ## Environment Variables
 
-| Variable     | Default | Description                                                                                                                                                                           |
-|--------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DIAL_SDK_LOG | WARNING | DIAL SDK log level                                                                                                                                                                    |
-| PYDANTIC_V2  | False   | When `True` and Pydantic V2 is installed, DIAL SDK classes for requests/responses will be based on Pydantic V2 `BaseModel`. Otherwise, they will be based on Pydantic V1 `BaseModel`. |
+|Variable|Default|Description|
+|---|---|---|
+|DIAL_SDK_LOG|WARNING|DIAL SDK log level|
+|DIAL_SDK_HEADERS_TO_PROXY|``|A comma-separated list of headers that should be proxied from incoming requests to outgoing requests to the DIAL API. By default, no headers are proxied.|
+|PYDANTIC_V2|False|When `True` and Pydantic V2 is installed, DIAL SDK classes for requests/responses will be based on Pydantic V2 `BaseModel`. Otherwise, they will be based on Pydantic V1 `BaseModel`.|
 
 ---
 

--- a/aidial_sdk/application.py
+++ b/aidial_sdk/application.py
@@ -80,7 +80,7 @@ class DIALApp(FastAPI):
         add_healthcheck: bool = False,
         *,
         allow_extra_request_fields: bool = False,
-        propagate_headers: list[str] | None = None,
+        headers_to_proxy: list[str] | None = None,
         **kwargs,
     ):
         if "propagation_auth_headers" in kwargs:
@@ -99,10 +99,10 @@ class DIALApp(FastAPI):
 
         self.configure_telemetry(telemetry_config)
 
-        propagate_headers = propagate_headers or []
-        propagate_headers.extend(env_var_list("DIAL_SDK_HEADERS_TO_PROXY"))
+        headers_to_proxy = headers_to_proxy or []
+        headers_to_proxy.extend(env_var_list("DIAL_SDK_HEADERS_TO_PROXY"))
 
-        if propagate_auth_headers or propagate_headers:
+        if propagate_auth_headers or headers_to_proxy:
             if not dial_url:
                 raise ValueError(
                     "dial_url is required if propagation of headers is enabled"
@@ -112,7 +112,7 @@ class DIALApp(FastAPI):
                 self,
                 dial_url=dial_url,
                 proxy_auth_headers=propagate_auth_headers,
-                headers_to_proxy=propagate_headers,
+                headers_to_proxy=headers_to_proxy,
             ).enable()
 
         if add_healthcheck:

--- a/aidial_sdk/application.py
+++ b/aidial_sdk/application.py
@@ -32,6 +32,7 @@ from aidial_sdk.header_propagator import HeaderPropagator
 from aidial_sdk.telemetry.types import TelemetryConfig
 from aidial_sdk.utils._disconnect_middleware import DisconnectMiddleware
 from aidial_sdk.utils._reflection import get_method_implementation
+from aidial_sdk.utils.env import env_var_list
 from aidial_sdk.utils.log_config import LogConfig
 from aidial_sdk.utils.logging import log_debug, set_log_deployment
 from aidial_sdk.utils.pydantic import model_validate_extra_fields
@@ -98,6 +99,9 @@ class DIALApp(FastAPI):
 
         self.configure_telemetry(telemetry_config)
 
+        propagate_headers = propagate_headers or []
+        propagate_headers.extend(env_var_list("DIAL_SDK_HEADERS_TO_PROXY"))
+
         if propagate_auth_headers or propagate_headers:
             if not dial_url:
                 raise ValueError(
@@ -108,7 +112,7 @@ class DIALApp(FastAPI):
                 self,
                 dial_url=dial_url,
                 proxy_auth_headers=propagate_auth_headers,
-                headers_to_proxy=propagate_headers or [],
+                headers_to_proxy=propagate_headers,
             ).enable()
 
         if add_healthcheck:

--- a/aidial_sdk/application.py
+++ b/aidial_sdk/application.py
@@ -79,6 +79,7 @@ class DIALApp(FastAPI):
         add_healthcheck: bool = False,
         *,
         allow_extra_request_fields: bool = False,
+        propagate_headers: list[str] | None = None,
         **kwargs,
     ):
         if "propagation_auth_headers" in kwargs:
@@ -97,13 +98,18 @@ class DIALApp(FastAPI):
 
         self.configure_telemetry(telemetry_config)
 
-        if propagate_auth_headers:
+        if propagate_auth_headers or propagate_headers:
             if not dial_url:
                 raise ValueError(
-                    "dial_url is required if propagation auth headers is enabled"
+                    "dial_url is required if propagation of headers is enabled"
                 )
 
-            HeaderPropagator(self, dial_url).enable()
+            HeaderPropagator(
+                self,
+                dial_url=dial_url,
+                proxy_auth_headers=propagate_auth_headers,
+                headers_to_proxy=propagate_headers or [],
+            ).enable()
 
         if add_healthcheck:
             path = "/health"

--- a/aidial_sdk/header_propagator.py
+++ b/aidial_sdk/header_propagator.py
@@ -12,17 +12,20 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 @dataclass
 class FastAPIMiddleware:
     app: ASGIApp
-    api_key: ContextVar[str | None]
-    conversation_id: ContextVar[str | None]
+    headers_to_proxy: list[str]
+    request_headers: ContextVar[dict[str, str] | None]
 
     async def __call__(
         self, scope: Scope, receive: Receive, send: Send
     ) -> None:
+        headers: dict[str, str] = {}
         for key, value in scope.get("headers") or []:
-            if key == b"api-key":
-                self.api_key.set(value.decode("utf-8"))
-            if key == b"x-conversation-id":
-                self.conversation_id.set(value.decode("utf-8"))
+            key = key.decode("utf-8")
+            value = value.decode("utf-8")
+            if key in self.headers_to_proxy:
+                headers[key] = value
+
+        self.request_headers.set(headers)
 
         await self.app(scope, receive, send)
 
@@ -43,28 +46,44 @@ def _normalize_url(url: str) -> str:
 class HeaderPropagator:
     _app: FastAPI
     _dial_url: str
-    _api_key: ContextVar[str | None]
-    _conversation_id: ContextVar[str | None]
+
+    _headers_to_proxy: list[str]
+    _request_headers: ContextVar[dict[str, str] | None]
+
     _enabled: bool
 
     _original_requests_send: Any | None
     _original_httpx_build_requests: tuple[Any, Any] | None
     _original_aiohttp_request: Any | None
 
-    def __init__(self, app: FastAPI, dial_url: str):
+    def __init__(
+        self,
+        app: FastAPI,
+        *,
+        dial_url: str,
+        proxy_auth_headers: bool,
+        headers_to_proxy: list[str],
+    ):
         self._app = app
         self._dial_url = _normalize_url(dial_url)
 
-        self._api_key = ContextVar("api_key", default=None)
-        self._conversation_id = ContextVar("conversation_id", default=None)
+        self._headers_to_proxy = [s.lower() for s in headers_to_proxy]
+        if proxy_auth_headers:
+            self._headers_to_proxy.append("api-key")
+
+        self._request_headers = ContextVar("request_headers", default=None)
 
         self._enabled = False
         self._original_requests_send = None
         self._original_httpx_build_requests = None
         self._original_aiohttp_request = None
 
+    @property
+    def is_noop(self) -> bool:
+        return not self._headers_to_proxy
+
     def enable(self):
-        if not self._enabled:
+        if not self.is_noop and not self._enabled:
             self._enabled = True
             self._instrument_fast_api(self._app)
             self._instrument_aiohttp()
@@ -72,7 +91,7 @@ class HeaderPropagator:
             self._instrument_httpx()
 
     def disable(self):
-        if self._enabled:
+        if not self.is_noop and self._enabled:
             self._enabled = False
             self._deinstrument_aiohttp()
             self._deinstrument_httpx()
@@ -81,8 +100,8 @@ class HeaderPropagator:
     def _instrument_fast_api(self, app: FastAPI):
         app.add_middleware(
             FastAPIMiddleware,
-            api_key=self._api_key,
-            conversation_id=self._conversation_id,
+            headers_to_proxy=self._headers_to_proxy,
+            request_headers=self._request_headers,
         )
 
     def _instrument_aiohttp(self):
@@ -182,8 +201,13 @@ class HeaderPropagator:
     def _modify_headers(
         self, url: str, headers: MutableMapping[str, str]
     ) -> None:
-        if _normalize_url(url).startswith(self._dial_url):
-            if api_key := self._api_key.get():
+        if not _normalize_url(url).startswith(self._dial_url):
+            return
+
+        request_headers = self._request_headers.get() or {}
+
+        for header, value in request_headers.items():
+            if header == "api-key":
                 old_api_key = headers.get("api-key")
                 old_authz = headers.get("Authorization")
 
@@ -192,9 +216,9 @@ class HeaderPropagator:
                     and old_authz
                     and old_authz == f"Bearer {old_api_key}"
                 ):
-                    headers["Authorization"] = f"Bearer {api_key}"
+                    headers["Authorization"] = f"Bearer {value}"
 
-                headers["api-key"] = api_key
+                headers["api-key"] = value
 
-            if conversation_id := self._conversation_id.get():
-                headers["x-conversation-id"] = conversation_id
+            elif header not in headers:
+                headers[header] = value

--- a/tests/test_header_propagation.py
+++ b/tests/test_header_propagation.py
@@ -61,10 +61,19 @@ def _all_urls() -> Generator[tuple[str, str, bool], Any, Any]:
 
 
 @contextlib.contextmanager
-def create_client(dial_url: str):
+def create_client(
+    dial_url: str,
+    proxy_auth_headers: bool = False,
+    headers_to_proxy: list[str] | None = None,
+):
     app = FastAPI()
     app.include_router(sender.router)
-    prop = HeaderPropagator(app, dial_url)
+    prop = HeaderPropagator(
+        app,
+        dial_url=dial_url,
+        proxy_auth_headers=proxy_auth_headers,
+        headers_to_proxy=headers_to_proxy or [],
+    )
     prop.enable()
     yield TestClient(app)
     prop.disable()
@@ -205,7 +214,7 @@ class TestCase:
 def test_api_key_propagation(lib: Lib, tc: TestCase):
     with (
         mock_upstream(lib, tc.upstream_url),
-        create_client(tc.dial_url) as client,
+        create_client(tc.dial_url, proxy_auth_headers=True) as client,
     ):
         headers_for_dial_app = {}
         if tc.key_for_dial_app:
@@ -255,7 +264,12 @@ def test_conversation_id_propagation(
     header_for_dial_app: str | None,
     header_for_upstream: str | None,
 ):
-    with mock_upstream(lib, upstream_url), create_client(dial_url) as client:
+    with (
+        mock_upstream(lib, upstream_url),
+        create_client(
+            dial_url, headers_to_proxy=["x-conversation-id"]
+        ) as client,
+    ):
         headers_for_dial_app = remove_nones(
             {"x-ConVersaTion-Id": header_for_dial_app}
         )
@@ -274,10 +288,10 @@ def test_conversation_id_propagation(
         )
 
         expected_value = None
-        if is_matching and header_for_dial_app:
-            expected_value = header_for_dial_app
-        elif header_for_upstream:
+        if header_for_upstream:
             expected_value = header_for_upstream
+        elif is_matching and header_for_dial_app:
+            expected_value = header_for_dial_app
 
         expected_headers = remove_nones({"x-conversation-id": expected_value})
 

--- a/tests/test_header_propagation.py
+++ b/tests/test_header_propagation.py
@@ -267,7 +267,7 @@ def test_conversation_id_propagation(
     with (
         mock_upstream(lib, upstream_url),
         create_client(
-            dial_url, headers_to_proxy=["x-conversation-id"]
+            dial_url, headers_to_proxy=["x-conVerSation-id"]
         ) as client,
     ):
         headers_for_dial_app = remove_nones(


### PR DESCRIPTION
Follow-up of https://github.com/epam/ai-dial-sdk/pull/363
The fix removes propagation of `x-conversation-id` **by default** _(which was a breaking change)_, and instead, this feature should be enabled **explicitly** either in the code:

```py
app = DIALApp(DIAL_URL, headers_to_proxy=["x-conversation-id"])
```

or via the env var:

```ini
DIAL_SDK_HEADERS_TO_PROXY=x-conversation-id
```