### PR TITLE
feat: support top-level cache breakpoint in Chat Completions request

### DIFF
--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -283,6 +283,7 @@ class AzureChatCompletionRequest(ExtraAllowModel):
 
 class ChatCompletionRequestCustomFields(ExtraAllowModel):
     configuration: dict[str, Any] | None = None
+    cache_breakpoint: CacheBreakpoint | None = None
 
 
 class ChatCompletionRequest(AzureChatCompletionRequest):


### PR DESCRIPTION
Required for the integration with Claude [automatic caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching), which is enabled by a `cache_control` field on the request top-level.