### PR TITLE
feat: add environment variable enabling heartbeats for streaming chat completion responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Applications and model adapters implemented using this framework will be compati
 |---|---|---|
 |DIAL_SDK_LOG|WARNING|DIAL SDK log level|
 |DIAL_SDK_HEADERS_TO_PROXY|``|A comma-separated list of headers that should be proxied from incoming requests to outgoing requests to the DIAL API. By default, no headers are proxied.|
+|DIAL_SDK_SSE_HEARTBEAT_INTERVAL||When set, the SDK inserts ping comments into streaming chat completion responses after the response has been idle for the specified number of seconds, helping prevent read timeouts when the DIAL application isn't responsive.|
 |PYDANTIC_V2|False|When `True` and Pydantic V2 is installed, DIAL SDK classes for requests/responses will be based on Pydantic V2 `BaseModel`. Otherwise, they will be based on Pydantic V1 `BaseModel`.|
 
 ---

--- a/aidial_sdk/application.py
+++ b/aidial_sdk/application.py
@@ -32,7 +32,7 @@ from aidial_sdk.header_propagator import HeaderPropagator
 from aidial_sdk.telemetry.types import TelemetryConfig
 from aidial_sdk.utils._disconnect_middleware import DisconnectMiddleware
 from aidial_sdk.utils._reflection import get_method_implementation
-from aidial_sdk.utils.env import env_var_list
+from aidial_sdk.utils.env import env_float, env_var_list
 from aidial_sdk.utils.log_config import LogConfig
 from aidial_sdk.utils.logging import log_debug, set_log_deployment
 from aidial_sdk.utils.pydantic import model_validate_extra_fields
@@ -279,6 +279,10 @@ class DIALApp(FastAPI):
         *,
         heartbeat_interval: float | None,
     ):
+        heartbeat_interval = heartbeat_interval or env_float(
+            "DIAL_SDK_SSE_HEARTBEAT_INTERVAL"
+        )
+
         async def _handler(original_request: Request):
             request = await self._parse_request(
                 ChatCompletionRequest, original_request, deployment_id

--- a/aidial_sdk/utils/env.py
+++ b/aidial_sdk/utils/env.py
@@ -5,6 +5,12 @@ def env_bool(name: str, default: bool) -> bool:
     return os.getenv(name, str(default)).lower() in ["true", "1"]
 
 
+def env_float(name: str) -> float | None:
+    if (value := os.getenv(name)) is not None:
+        return float(value)
+    return None
+
+
 def env_var_list(name: str) -> list[str]:
     value = os.getenv(name)
     if value is None:

--- a/examples/langchain_rag/.env.example
+++ b/examples/langchain_rag/.env.example
@@ -9,6 +9,10 @@ API_VERSION=2024-02-01
 # Enabling debug logs for DIAL SDK
 DIAL_SDK_LOG=debug
 
+# Enabling SSE heartbeats for streaming chat completion responses
+# after the response was idle for 10 seconds.
+DIAL_SDK_SSE_HEARTBEAT_INTERVAL=10
+
 # Enabling debug logs for OpenAI and Langchain
 OPENAI_LOG=debug
 LANGCHAIN_DEBUG=true


### PR DESCRIPTION
Analogous to the fix in adapter OpenAI: https://github.com/epam/ai-dial-adapter-openai/pull/411:

|Variable|Default|Description|
|---|---|---|
|DIAL_SDK_SSE_HEARTBEAT_INTERVAL||When set, the SDK inserts ping comments into streaming chat completion responses after the response has been idle for the specified number of seconds, helping prevent read timeouts when the DIAL application isn't responsive.|