### PR TITLE
ci: re-use venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,16 @@ VENV_DIR ?= .venv
 POETRY ?= poetry
 POETRY_PYTHON ?= python
 
+# Any non-empty CI value (even 'false' or '0') means that CI is enabled
+CI ?=
+
 -include .env.dev
 export
 
 all: build
 
 init_env:
-	$(POETRY) env use $(POETRY_PYTHON)
+	$(if $(CI),,$(POETRY) env use $(POETRY_PYTHON))
 
 install: init_env
 	$(POETRY) install --all-extras

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,12 +1,8 @@
-import os
-
 from enum import Enum
 
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
-if os.environ.get("CI"):
-    nox.options.default_venv_backend = "none"
 
 SRC = ["aidial_sdk", "tests", "noxfile.py", "examples"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,8 +1,12 @@
+import os
+
 from enum import Enum
 
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+if os.environ.get("CI"):
+    nox.options.default_venv_backend = "none"
 
 SRC = ["aidial_sdk", "tests", "noxfile.py", "examples"]
 


### PR DESCRIPTION
CI speed-up:
- skip `poetry env use` when running in CI environment - no need to recreate the venv we already prepared in workflow script (`python_prepare` action)

For local execution everything stays the same