### PR TITLE
feat: support completion_tokens_details and cache_write_tokens in usage

### DIFF
--- a/aidial_sdk/chat_completion/chunks.py
+++ b/aidial_sdk/chat_completion/chunks.py
@@ -374,6 +374,11 @@ class Attachment(BaseModel):
 
 class PromptTokensDetails(TypedDict, total=False):
     cached_tokens: int
+    cache_write_tokens: int
+
+
+class CompletionTokensDetails(TypedDict, total=False):
+    reasoning_tokens: int
 
 
 class AttachmentChunk(Attachment, BaseChunk):
@@ -445,16 +450,19 @@ class UsageChunk(BaseChunk):
     prompt_tokens: int
     completion_tokens: int
     prompt_tokens_details: PromptTokensDetails | None
+    completion_tokens_details: CompletionTokensDetails | None
 
     def __init__(
         self,
         prompt_tokens: int,
         completion_tokens: int,
         prompt_tokens_details: PromptTokensDetails | None,
+        completion_tokens_details: CompletionTokensDetails | None,
     ):
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
         self.prompt_tokens_details = prompt_tokens_details
+        self.completion_tokens_details = completion_tokens_details
 
     def to_dict(self):
         return {
@@ -465,6 +473,13 @@ class UsageChunk(BaseChunk):
                 **(
                     {"prompt_tokens_details": self.prompt_tokens_details}
                     if self.prompt_tokens_details
+                    else {}
+                ),
+                **(
+                    {
+                        "completion_tokens_details": self.completion_tokens_details
+                    }
+                    if self.completion_tokens_details
                     else {}
                 ),
             }

--- a/aidial_sdk/chat_completion/response.py
+++ b/aidial_sdk/chat_completion/response.py
@@ -13,6 +13,7 @@ from aidial_sdk.chat_completion.chunks import (
     ArbitraryChunk,
     BaseChunk,
     BaseChunkWithDefaults,
+    CompletionTokensDetails,
     DefaultChunk,
     DiscardedMessagesChunk,
     EndChoiceChunk,
@@ -217,6 +218,7 @@ class Response:
         completion_tokens: int = 0,
         *,
         prompt_tokens_details: PromptTokensDetails | None = None,
+        completion_tokens_details: CompletionTokensDetails | None = None,
     ):
         self._generation_started = True
 
@@ -229,7 +231,12 @@ class Response:
 
         self._usage_generated = True
         self._queue.put_nowait(
-            UsageChunk(prompt_tokens, completion_tokens, prompt_tokens_details)
+            UsageChunk(
+                prompt_tokens,
+                completion_tokens,
+                prompt_tokens_details,
+                completion_tokens_details,
+            )
         )
 
     async def aflush(self):

--- a/tests/test_usage_chunk.py
+++ b/tests/test_usage_chunk.py
@@ -1,0 +1,38 @@
+from aidial_sdk.chat_completion.chunks import UsageChunk
+
+
+def test_usage_chunk_with_token_details():
+    chunk = UsageChunk(
+        prompt_tokens=10,
+        completion_tokens=20,
+        prompt_tokens_details={"cached_tokens": 3, "cache_write_tokens": 5},
+        completion_tokens_details={"reasoning_tokens": 7},
+    )
+    assert chunk.to_dict() == {
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+            "prompt_tokens_details": {
+                "cached_tokens": 3,
+                "cache_write_tokens": 5,
+            },
+            "completion_tokens_details": {"reasoning_tokens": 7},
+        }
+    }
+
+
+def test_usage_chunk_without_token_details():
+    chunk = UsageChunk(
+        prompt_tokens=10,
+        completion_tokens=20,
+        prompt_tokens_details=None,
+        completion_tokens_details=None,
+    )
+    assert chunk.to_dict() == {
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        }
+    }


### PR DESCRIPTION
Support `completion_tokens_details.reasoning_tokens` and `prompt_tokens_details.cache_write_tokens` as per [OpenAI API](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20chat.completions%20%3E%20(model)%20chat_completion%20%3E%20(schema)%20%3E%20(property)%20usage).
