### PR TITLE
chore: bump pypdf from 6.13.3 to 6.14.2 in examples/langchain_rag

### DIFF
--- a/examples/langchain_rag/requirements.txt
+++ b/examples/langchain_rag/requirements.txt
@@ -9,4 +9,4 @@ httpx==0.28.1
 beautifulsoup4==4.14.3
 chromadb==1.5.8
 uvicorn==0.44.0
-pypdf==6.14.1
+pypdf==6.14.2

--- a/examples/langchain_rag/requirements.txt
+++ b/examples/langchain_rag/requirements.txt
@@ -9,4 +9,4 @@ httpx==0.28.1
 beautifulsoup4==4.14.3
 chromadb==1.5.8
 uvicorn==0.44.0
-pypdf==6.13.3
+pypdf==6.14.1


### PR DESCRIPTION
Fixing CVE-2026-59935 and CVE-2026-59936