### PR TITLE
chore: document and enforce that log correlation requires OTEL_TRACES_EXPORTER

### DIFF
--- a/aidial_sdk/utils/log_config.py
+++ b/aidial_sdk/utils/log_config.py
@@ -8,6 +8,7 @@ from uvicorn.logging import DefaultFormatter
 from aidial_sdk.telemetry.types import (
     OTEL_LOGS_EXPORTER,
     OTEL_PYTHON_LOG_CORRELATION,
+    OTEL_TRACES_EXPORTER,
 )
 from aidial_sdk.utils._json_log_formatter import JsonLogFormatter
 from aidial_sdk.utils._logging import remove_stream_handlers
@@ -63,7 +64,12 @@ class LogConfig:
 
 
 def _otel_installed_root_logger() -> bool:
-    return OTEL_PYTHON_LOG_CORRELATION or "console" in OTEL_LOGS_EXPORTER
+    # Log correlation only takes effect when tracing is on: without
+    # OTEL_TRACES_EXPORTER no TracingConfig is built, so OTel never installs a
+    # root handler and the SDK must keep its own.
+    return (
+        OTEL_PYTHON_LOG_CORRELATION and bool(OTEL_TRACES_EXPORTER)
+    ) or "console" in OTEL_LOGS_EXPORTER
 
 
 def configure_root_logger(config: LogConfig | None = None) -> None:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -8,31 +8,42 @@ defaults and examples.
 
 ## Which one do I pick?
 
+The axis that separates them is **who owns the record's shape** — not trace
+context, which all three can carry (§1 needs tracing on, see
+[Adding trace and span IDs](#adding-trace-and-span-ids)).
+
 ```
-Do you need OTel-native structured JSON
-(rich attributes + resource + trace context, ready for a log pipeline)?
+Do you want JSON in a shape you define
+(your own keys, nesting, subset of fields)?
 │
-├─ YES ─────────────────────────────► OTEL_LOGS_EXPORTER=console      → §3
-│                                      ignores every DIAL_SDK_LOG_FORMAT var
+├─ YES ─────────────────────────────► DIAL_SDK_LOG_FORMAT=json         → §1
+│                                      DIAL_SDK_JSON_LOG_FORMAT=<template>
+│                                      the only way to get custom-shaped JSON
 │
-└─ NO ─► Want plain text with trace_id/span_id injected automatically?
+└─ NO ─► Do you need OTel-native structured logs (rich attributes + resource
+         + trace context, ready for a log pipeline), shape fixed by OTel?
          │
-         ├─ YES ─────────────────────► OTEL_TRACES_EXPORTER=otlp        → §2
-         │                              + OTEL_PYTHON_LOG_CORRELATION=true
+         ├─ YES ─────────────────────► OTEL_LOGS_EXPORTER=console|otlp  → §3
+         │                              ignores every DIAL_SDK_LOG_FORMAT var
          │
-         └─ NO ─► You control the format (the default):                 → §1
-                  DIAL_SDK_LOG_FORMAT=text   colored, human-readable
-                  DIAL_SDK_LOG_FORMAT=json   your own JSON shape
+         └─ NO ─► Text, then. Whose template?
+                  │
+                  ├─ OTel's, trace fields already in it ──────────────► §2
+                  │   OTEL_TRACES_EXPORTER=otlp
+                  │   + OTEL_PYTHON_LOG_CORRELATION=true
+                  │
+                  └─ Yours (the default, no telemetry required) ──────► §1
+                      DIAL_SDK_LOG_FORMAT=text  colored, human-readable
 ```
 
 Required var in **bold**, optional (customization) vars in plain:
 
 | You want | Set | Section |
 | --- | --- | --- |
-| Custom **text** format (default) | **`DIAL_SDK_LOG_FORMAT=text`** · `DIAL_SDK_TEXT_LOG_FORMAT` · `DIAL_SDK_LOG` | [§1](#1-dial-sdk-formatter) |
-| Custom **JSON** format | **`DIAL_SDK_LOG_FORMAT=json`** · `DIAL_SDK_JSON_LOG_FORMAT` · `DIAL_SDK_LOG` | [§1](#1-dial-sdk-formatter) |
-| Plain text **+ trace context** injected automatically | **`OTEL_TRACES_EXPORTER=otlp`** **and** **`OTEL_PYTHON_LOG_CORRELATION=true`** · `OTEL_PYTHON_LOG_FORMAT` | [§2](#2-otel-log-correlation) |
-| **OTel-native structured JSON** | **`OTEL_LOGS_EXPORTER=console`** | [§3](#3-otel-log-export) |
+| **JSON in your own shape** | **`DIAL_SDK_LOG_FORMAT=json`** · `DIAL_SDK_JSON_LOG_FORMAT` · `DIAL_SDK_LOG` | [§1](#1-dial-sdk-formatter) |
+| **Text in your own format** (default) | **`DIAL_SDK_LOG_FORMAT=text`** · `DIAL_SDK_TEXT_LOG_FORMAT` · `DIAL_SDK_LOG` | [§1](#1-dial-sdk-formatter) |
+| **Text in OTel's correlated format**, no template to write | **`OTEL_TRACES_EXPORTER=otlp`** **and** **`OTEL_PYTHON_LOG_CORRELATION=true`** · `OTEL_PYTHON_LOG_FORMAT` | [§2](#2-otel-log-correlation) |
+| **OTel-native structured logs** (shape fixed by OTel) | **`OTEL_LOGS_EXPORTER=console`** or `otlp` | [§3](#3-otel-log-export) |
 
 **Prerequisite:** §2 and §3 require telemetry — the `telemetry` extra
 (`aidial-sdk[telemetry]`) **and** `DIALApp(telemetry_config=TelemetryConfig())`.
@@ -140,6 +151,10 @@ Requires telemetry **and** tracing — it only takes effect together with
 `OTEL_TRACES_EXPORTER=otlp`; without it the SDK builds no `TracingConfig` and
 the flag is silently ignored. Its handler takes precedence over §1's text
 formatter.
+
+Versus §1 text with `%(otelTraceID)s` placeholders: same information, but the
+template is OTel's ready-made one and it renders `0` rather than raising
+`KeyError` when tracing is off.
 
 ```sh
 OTEL_TRACES_EXPORTER=otlp

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -8,32 +8,28 @@ defaults and examples.
 
 ## Which one do I pick?
 
-The axis that separates them is **who owns the record's shape** — not trace
-context, which all three can carry (§1 needs tracing on, see
-[Adding trace and span IDs](#adding-trace-and-span-ids)).
-
-```
+```txt
 Do you want JSON in a shape you define
 (your own keys, nesting, subset of fields)?
 │
-├─ YES ─────────────────────────────► DIAL_SDK_LOG_FORMAT=json         → §1
-│                                      DIAL_SDK_JSON_LOG_FORMAT=<template>
-│                                      the only way to get custom-shaped JSON
+├─ YES ──────────► DIAL_SDK_LOG_FORMAT=json ───────────────────────────► §1
+│                   DIAL_SDK_JSON_LOG_FORMAT=<template>
+│                   the only way to get custom-shaped JSON
 │
 └─ NO ─► Do you need OTel-native structured logs (rich attributes + resource
          + trace context, ready for a log pipeline), shape fixed by OTel?
          │
-         ├─ YES ─────────────────────► OTEL_LOGS_EXPORTER=console|otlp  → §3
-         │                              ignores every DIAL_SDK_LOG_FORMAT var
+         ├─ YES ─► OTEL_LOGS_EXPORTER=console  ────────────────────────► §3
          │
-         └─ NO ─► Text, then. Whose template?
-                  │
-                  ├─ OTel's, trace fields already in it ──────────────► §2
-                  │   OTEL_TRACES_EXPORTER=otlp
-                  │   + OTEL_PYTHON_LOG_CORRELATION=true
-                  │
-                  └─ Yours (the default, no telemetry required) ──────► §1
-                      DIAL_SDK_LOG_FORMAT=text  colored, human-readable
+         └─ NO ──► Text, then. Whose template?
+                   │
+                   ├─ OTel's, trace fields already in it ──────────────► §2
+                   │   OTEL_TRACES_EXPORTER=otlp
+                   │   OTEL_PYTHON_LOG_CORRELATION=true
+                   │
+                   └─ Yours (the default, no telemetry required) ──────► §1
+                       DIAL_SDK_LOG_FORMAT=text (colored, human-readable)
+                       DIAL_SDK_TEXT_LOG_FORMAT=<template>
 ```
 
 Required var in **bold**, optional (customization) vars in plain:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -17,7 +17,8 @@ Do you need OTel-native structured JSON
 │
 └─ NO ─► Want plain text with trace_id/span_id injected automatically?
          │
-         ├─ YES ─────────────────────► OTEL_PYTHON_LOG_CORRELATION=true → §2
+         ├─ YES ─────────────────────► OTEL_TRACES_EXPORTER=otlp        → §2
+         │                              + OTEL_PYTHON_LOG_CORRELATION=true
          │
          └─ NO ─► You control the format (the default):                 → §1
                   DIAL_SDK_LOG_FORMAT=text   colored, human-readable
@@ -30,12 +31,14 @@ Required var in **bold**, optional (customization) vars in plain:
 | --- | --- | --- |
 | Custom **text** format (default) | **`DIAL_SDK_LOG_FORMAT=text`** · `DIAL_SDK_TEXT_LOG_FORMAT` · `DIAL_SDK_LOG` | [§1](#1-dial-sdk-formatter) |
 | Custom **JSON** format | **`DIAL_SDK_LOG_FORMAT=json`** · `DIAL_SDK_JSON_LOG_FORMAT` · `DIAL_SDK_LOG` | [§1](#1-dial-sdk-formatter) |
-| Plain text **+ trace context** injected automatically | **`OTEL_PYTHON_LOG_CORRELATION=true`** · `OTEL_PYTHON_LOG_FORMAT` | [§2](#2-otel-log-correlation) |
+| Plain text **+ trace context** injected automatically | **`OTEL_TRACES_EXPORTER=otlp`** **and** **`OTEL_PYTHON_LOG_CORRELATION=true`** · `OTEL_PYTHON_LOG_FORMAT` | [§2](#2-otel-log-correlation) |
 | **OTel-native structured JSON** | **`OTEL_LOGS_EXPORTER=console`** | [§3](#3-otel-log-export) |
 
 **Prerequisite:** §2 and §3 require telemetry — the `telemetry` extra
 (`aidial-sdk[telemetry]`) **and** `DIALApp(telemetry_config=TelemetryConfig())`.
-§1 works with or without it. The three ways are mutually exclusive: enabling §3
+§2 additionally requires tracing to be enabled (`OTEL_TRACES_EXPORTER=otlp`):
+`OTEL_PYTHON_LOG_CORRELATION=true` on its own is a no-op, since there is no
+trace context to inject. §1 works with or without telemetry. The three ways are mutually exclusive: enabling §3
 makes the SDK ignore §1's format vars; §2 replaces §1's text formatter with
 OTel's.
 
@@ -133,9 +136,13 @@ INFO:     | 2026-07-16 13:10:42 | trace_id=36d9c402... span_id=61f3846d... | hel
 
 `OTEL_PYTHON_LOG_CORRELATION=true` is OTel's own way to add trace context to
 **text** logs, with a built-in format overridable via `OTEL_PYTHON_LOG_FORMAT`.
-Requires telemetry. Its handler takes precedence over §1's text formatter.
+Requires telemetry **and** tracing — it only takes effect together with
+`OTEL_TRACES_EXPORTER=otlp`; without it the SDK builds no `TracingConfig` and
+the flag is silently ignored. Its handler takes precedence over §1's text
+formatter.
 
 ```sh
+OTEL_TRACES_EXPORTER=otlp
 OTEL_PYTHON_LOG_CORRELATION=true
 OTEL_PYTHON_LOG_FORMAT='%(asctime)s %(levelname)s trace_id=%(otelTraceID)s - %(message)s'
 →

--- a/tests/test_configure_root_logger.py
+++ b/tests/test_configure_root_logger.py
@@ -57,6 +57,10 @@ def test_defers_to_otel_correlation_handler(clean_root, monkeypatch):
     monkeypatch.setattr(
         "aidial_sdk.utils.log_config.OTEL_PYTHON_LOG_CORRELATION", True
     )
+    # correlation only takes effect when tracing is on
+    monkeypatch.setattr(
+        "aidial_sdk.utils.log_config.OTEL_TRACES_EXPORTER", ["otlp"]
+    )
     otel_console = logging.StreamHandler(sys.stderr)
     clean_root.addHandler(otel_console)
 
@@ -66,9 +70,29 @@ def test_defers_to_otel_correlation_handler(clean_root, monkeypatch):
     assert _stderr_console_handlers(clean_root) == [otel_console]
 
 
+def test_correlation_without_traces_exporter_keeps_sdk_handler(
+    clean_root, monkeypatch
+):
+    # OTEL_PYTHON_LOG_CORRELATION alone installs no OTel root handler (no
+    # TracingConfig without OTEL_TRACES_EXPORTER), so we must not defer to it —
+    # otherwise records fall through to logging's unformatted lastResort.
+    monkeypatch.setattr(
+        "aidial_sdk.utils.log_config.OTEL_PYTHON_LOG_CORRELATION", True
+    )
+    monkeypatch.setattr("aidial_sdk.utils.log_config.OTEL_TRACES_EXPORTER", [])
+
+    configure_root_logger()
+
+    assert len(_stderr_console_handlers(clean_root)) == 1
+
+
 def test_honors_otel_python_log_format(clean_root, monkeypatch, capsys):
     monkeypatch.setattr(
         "aidial_sdk.utils.log_config.OTEL_PYTHON_LOG_CORRELATION", True
+    )
+    # correlation only takes effect when tracing is on
+    monkeypatch.setattr(
+        "aidial_sdk.utils.log_config.OTEL_TRACES_EXPORTER", ["otlp"]
     )
     monkeypatch.setenv("OTEL_PYTHON_LOG_CORRELATION", "true")
     monkeypatch.setenv(

--- a/tests/test_configure_root_logger.py
+++ b/tests/test_configure_root_logger.py
@@ -11,8 +11,7 @@ def _stderr_console_handlers(root):
     return [
         h
         for h in root.handlers
-        if isinstance(h, logging.StreamHandler)
-        and getattr(h, "stream", None) is sys.stderr
+        if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
     ]
 
 

--- a/tests/test_telemetry_logs.py
+++ b/tests/test_telemetry_logs.py
@@ -195,6 +195,32 @@ def test_correlation_format_is_overridable():
     assert lines == ["OTELFMT WARNING trace=0 hello"]
 
 
+def test_correlation_env_var_requires_traces_exporter():
+    # OTEL_PYTHON_LOG_CORRELATION alone is a no-op: without OTEL_TRACES_EXPORTER
+    # TelemetryConfig builds no TracingConfig, so §1's formatter stays in charge.
+    lines = run(
+        emit("hello", logger="aidial_sdk"),
+        env={"OTEL_PYTHON_LOG_CORRELATION": "true"},
+        telemetry="TelemetryConfig()",
+    )
+    assert len(lines) == 1
+    assert "| aidial_sdk |" in lines[0] and lines[0].endswith("| hello")
+    assert "trace_id=" not in lines[0]
+
+
+def test_correlation_env_var_with_traces_exporter_enables_correlation():
+    lines = run(
+        emit("hello"),
+        env={
+            "OTEL_PYTHON_LOG_CORRELATION": "true",
+            "OTEL_TRACES_EXPORTER": "otlp",
+            "OTEL_PYTHON_LOG_FORMAT": "OTELFMT %(levelname)s trace=%(otelTraceID)s %(message)s",
+        },
+        telemetry="TelemetryConfig()",
+    )
+    assert lines == ["OTELFMT WARNING trace=0 hello"]
+
+
 def test_correlation_takes_over_third_party_handler():
     # openai grabs a root stderr handler at import (OPENAI_LOG=debug); correlation
     # must remove it so records render in OTel's format, not openai's "- app:NN -".


### PR DESCRIPTION
## Problem

`docs/logging.md` presented `OTEL_PYTHON_LOG_CORRELATION=true` as sufficient on its own to enable §2 (OTel log correlation). It isn't: `TelemetryConfig.tracing` is only built when `OTEL_TRACES_EXPORTER` is non-empty (`aidial_sdk/telemetry/types.py`), so without it `init_telemetry` never installs the logging instrumentor and the flag is a no-op.

Worse than a doc inaccuracy — `_otel_installed_root_logger()` trusted the flag the same way, so `configure_sdk_logger()` / `configure_root_logger()` deferred the console handler to OTel when OTel had installed nothing. Records then fell through to stdlib logging's `lastResort` handler and printed unformatted:

```
$ OTEL_PYTHON_LOG_CORRELATION=true python -c "..."
hello                                    # instead of the SDK text format
```

## Changes

- `aidial_sdk/utils/log_config.py` — `_otel_installed_root_logger()` now requires tracing to actually be enabled (`OTEL_PYTHON_LOG_CORRELATION and OTEL_TRACES_EXPORTER`). With correlation set but tracing off, the SDK keeps its own console handler and §1 formatting applies.
- `docs/logging.md` — decision tree, the mode table, the prerequisites paragraph and §2 now state that `OTEL_TRACES_EXPORTER=otlp` is required alongside the correlation flag.
- Tests pinning the contract:
  - `test_correlation_env_var_requires_traces_exporter` — the flag alone leaves §1's formatter in charge (no `trace_id=`).
  - `test_correlation_env_var_with_traces_exporter_enables_correlation` — both vars together produce OTel's correlated format.
  - `test_correlation_without_traces_exporter_keeps_sdk_handler` — `configure_root_logger()` installs its own console handler rather than deferring.
  - The two existing correlation tests in `test_configure_root_logger.py` now also set `OTEL_TRACES_EXPORTER`, matching the corrected contract.

No public API change; behavior only differs in the previously broken configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)