### PR TITLE
feat: support custom metric views in MetricsConfig

### DIFF
--- a/aidial_sdk/telemetry/init.py
+++ b/aidial_sdk/telemetry/init.py
@@ -132,7 +132,11 @@ def init_telemetry(app: FastAPI | None, config: TelemetryConfig):
             )
 
         set_meter_provider(
-            MeterProvider(resource=resource, metric_readers=metric_readers)
+            MeterProvider(
+                resource=resource,
+                metric_readers=metric_readers,
+                views=config.metrics.meter_provider_views or [],
+            )
         )
 
         SystemMetricsInstrumentor().instrument()

--- a/aidial_sdk/telemetry/types.py
+++ b/aidial_sdk/telemetry/types.py
@@ -1,8 +1,16 @@
 import logging
 import os
+from typing import TYPE_CHECKING, Any
 
 from aidial_sdk._pydantic._compat import BaseModel
 from aidial_sdk.utils.env import env_var_list
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.metrics.view import View
+else:
+    # The OTel SDK is an optional dependency, while this module is imported
+    # even without the `telemetry` extras. Pydantic sees `Any` at runtime.
+    View = Any
 
 # OpenTelemetry SDK configuration env vars:
 # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
@@ -36,6 +44,8 @@ class MetricsConfig(BaseModel):
     otlp_export: bool = "otlp" in OTEL_METRICS_EXPORTER
     prometheus_export: bool = "prometheus" in OTEL_METRICS_EXPORTER
     port: int = OTEL_EXPORTER_PROMETHEUS_PORT
+
+    meter_provider_views: list["View"] | None = None
 
 
 class TelemetryConfig(BaseModel):

--- a/tests/test_telemetry_metrics.py
+++ b/tests/test_telemetry_metrics.py
@@ -1,0 +1,59 @@
+import subprocess
+import sys
+import textwrap
+
+# The global MeterProvider can only be set once per process, so run in a subprocess.
+_SCRIPT = textwrap.dedent(
+    """
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics.view import (
+        ExplicitBucketHistogramAggregation,
+        View,
+    )
+    from prometheus_client import generate_latest
+
+    from aidial_sdk.telemetry.init import init_telemetry
+    from aidial_sdk.telemetry.types import MetricsConfig, TelemetryConfig
+
+    init_telemetry(
+        None,
+        TelemetryConfig(
+            metrics=MetricsConfig(
+                prometheus_export=True,
+                port=0,  # ephemeral: metrics are read from the registry below
+                views=[
+                    View(
+                        instrument_name="http.server.duration",
+                        aggregation=ExplicitBucketHistogramAggregation(
+                            (100, 500)
+                        ),
+                    )
+                ],
+            )
+        ),
+    )
+
+    metrics.get_meter("test").create_histogram(
+        "http.server.duration", unit="ms"
+    ).record(300)
+
+    print(generate_latest().decode())
+    """
+)
+
+
+def test_metrics_views_override_histogram_buckets():
+    out = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _SCRIPT], capture_output=True, text=True
+    ).stdout
+
+    buckets = [
+        line
+        for line in out.splitlines()
+        if line.startswith("http_server_duration_milliseconds_bucket")
+    ]
+    boundaries = [line.split('le="')[1].split('"')[0] for line in buckets]
+
+    assert boundaries == ["100", "500", "+Inf"], out
+    # The recorded 300ms lands in the (100, 500] bucket.
+    assert [line.rsplit(" ", 1)[1] for line in buckets] == ["0.0", "1.0", "1.0"]

--- a/tests/test_telemetry_metrics.py
+++ b/tests/test_telemetry_metrics.py
@@ -21,7 +21,7 @@ _SCRIPT = textwrap.dedent(
             metrics=MetricsConfig(
                 prometheus_export=True,
                 port=0,  # ephemeral: metrics are read from the registry below
-                views=[
+                meter_provider_views=[
                     View(
                         instrument_name="http.server.duration",
                         aggregation=ExplicitBucketHistogramAggregation(


### PR DESCRIPTION
`MetricsConfig` accepts a new optional `meter_provider_views` field — a list of `opentelemetry.sdk.metrics.view.View` — passed straight to the `MeterProvider`. Previously the only way to customize aggregation was to set the global `MeterProvider` before `init_telemetry` ran, which made the SDK's own provider silently lose (`Overriding of current MeterProvider is not allowed`).

Example — keep the default buckets of `http.server.duration` but extend them past 10s, up to 5 minutes:

```python
from fastapi import FastAPI
from opentelemetry.sdk.metrics.view import (
    ExplicitBucketHistogramAggregation,
    View,
)

from aidial_sdk.telemetry.init import init_telemetry
from aidial_sdk.telemetry.types import MetricsConfig, TelemetryConfig

app = FastAPI()

init_telemetry(
    app,
    TelemetryConfig(
        metrics=MetricsConfig(
            prometheus_export=True,
            meter_provider_views=[
                View(
                    # NOTE: `http.server.duration` is reported in MILLISECONDS
                    instrument_name="http.server.duration",
                    aggregation=ExplicitBucketHistogramAggregation(
                        # the SDK default boundaries stop at 10s...
                        (
                            0, 5, 10, 25, 50, 75, 100, 250, 500, 750,
                            1000, 2500, 5000, 7500, 10000,
                            # ...these are the extra ones
                            15000, 20000, 30000, 60000, 120000, 300000,
                        )
                    ),
                )
            ],
        )
    ),
)
```

Scraping `:9464/metrics` then reports `http_server_duration_milliseconds_bucket{...,le="300000"}` and friends.

`meter_provider_views` defaults to `None`, so existing applications are unaffected.