### PR TITLE
feat: Chat Completions API: support `reasoning_content` field

### DIFF
--- a/aidial_sdk/chat_completion/choice.py
+++ b/aidial_sdk/chat_completion/choice.py
@@ -11,6 +11,7 @@ from aidial_sdk.chat_completion.chunks import (
     ContentChunk,
     EndChoiceChunk,
     FormSchemaChunk,
+    ReasoningContentChunk,
     StartChoiceChunk,
     StateChunk,
 )
@@ -95,6 +96,18 @@ class Choice(ChoiceBase):
 
         self.send_chunk(ContentChunk(content, self._index))
         self._last_finish_reason = FinishReason.STOP
+
+    def append_reasoning_content(self, content: str) -> None:
+        if not self._opened:
+            raise runtime_error(
+                "Trying to append reasoning content to an unopened choice"
+            )
+        if self._closed:
+            raise runtime_error(
+                "Trying to append reasoning content to a closed choice"
+            )
+
+        self.send_chunk(ReasoningContentChunk(content, self._index))
 
     @property
     def content_stream(self) -> ContentStream:

--- a/aidial_sdk/chat_completion/chunks.py
+++ b/aidial_sdk/chat_completion/chunks.py
@@ -96,6 +96,27 @@ class ContentChunk(BaseChunk):
         }
 
 
+class ReasoningContentChunk(BaseChunk):
+    content: str
+    choice_index: int
+
+    def __init__(self, content: str, choice_index: int):
+        self.content = content
+        self.choice_index = choice_index
+
+    def to_dict(self):
+        return {
+            "choices": [
+                {
+                    "index": self.choice_index,
+                    "finish_reason": None,
+                    "delta": {"reasoning_content": self.content},
+                }
+            ],
+            "usage": None,
+        }
+
+
 class FunctionToolCallChunk(BaseChunk):
     choice_index: int
     call_index: int

--- a/aidial_sdk/chat_completion/request.py
+++ b/aidial_sdk/chat_completion/request.py
@@ -152,6 +152,7 @@ class Message(ExtraAllowModel):
     tool_call_id: StrictStr | None = None
     function_call: FunctionCall | None = None
     refusal: StrictStr | None = None
+    reasoning_content: StrictStr | None = None
 
     def text(self) -> str:
         """

--- a/tests/test_reasoning_content.py
+++ b/tests/test_reasoning_content.py
@@ -1,0 +1,60 @@
+import asyncio
+
+from aidial_sdk.chat_completion.choice import Choice
+from aidial_sdk.chat_completion.chunks import (
+    ContentChunk,
+    EndChoiceChunk,
+    ReasoningContentChunk,
+    StartChoiceChunk,
+)
+from aidial_sdk.chat_completion.enums import FinishReason
+from aidial_sdk.chat_completion.request import Message, Role
+from aidial_sdk.utils.merge_chunks import merge
+
+
+def test_message_reasoning_content_parsing():
+    msg = Message(
+        role=Role.ASSISTANT,
+        content="Final answer",
+        reasoning_content="Detailed step-by-step thinking process",
+    )
+    assert msg.role == Role.ASSISTANT
+    assert msg.content == "Final answer"
+    assert msg.reasoning_content == "Detailed step-by-step thinking process"
+
+
+def test_choice_append_reasoning_content():
+    queue = asyncio.Queue()
+    choice = Choice(queue=queue, choice_index=0)
+
+    choice.open()
+    choice.append_reasoning_content("Thinking part 1. ")
+    choice.append_reasoning_content("Thinking part 2.")
+    choice.append_content("Answer text.")
+    choice.close(FinishReason.STOP)
+
+    chunks = []
+    while not queue.empty():
+        chunks.append(queue.get_nowait())
+
+    assert len(chunks) == 5
+    assert isinstance(chunks[0], StartChoiceChunk)
+    assert isinstance(chunks[1], ReasoningContentChunk)
+    assert chunks[1].content == "Thinking part 1. "
+    assert chunks[1].to_dict()["choices"][0]["delta"] == {
+        "reasoning_content": "Thinking part 1. "
+    }
+    assert isinstance(chunks[2], ReasoningContentChunk)
+    assert chunks[2].content == "Thinking part 2."
+    assert isinstance(chunks[3], ContentChunk)
+    assert chunks[3].to_dict()["choices"][0]["delta"] == {
+        "content": "Answer text."
+    }
+    assert isinstance(chunks[4], EndChoiceChunk)
+
+    # Test chunk merge behavior (used for non-streaming response)
+    merged = merge(*[c.to_dict() for c in chunks])
+    delta = merged["choices"][0]["delta"]
+    assert delta["reasoning_content"] == "Thinking part 1. Thinking part 2."
+    assert delta["content"] == "Answer text."
+    assert merged["choices"][0]["finish_reason"] == "stop"


### PR DESCRIPTION
Fixes #434.

## Summary
- Add `reasoning_content` optional string field to `Message` in `aidial_sdk.chat_completion.request`
- Add `ReasoningContentChunk` to stream `delta.reasoning_content`
- Add `append_reasoning_content` method to `Choice`
- Automatically merge `reasoning_content` in non-streaming responses via existing `merge_chunks`
- Add unit test coverage in `tests/test_reasoning_content.py`

## Validation
- `uv run pytest tests/test_reasoning_content.py -q` - 2 passed
- `uv run pyright aidial_sdk/chat_completion/request.py aidial_sdk/chat_completion/chunks.py aidial_sdk/chat_completion/choice.py tests/test_reasoning_content.py` - 0 errors
- `uvx ruff check` - passed
- `uvx ruff format` - passed
